### PR TITLE
Move all optimizers to Optimisers.jl

### DIFF
--- a/src/Optimisers.jl
+++ b/src/Optimisers.jl
@@ -7,6 +7,6 @@ include("rules.jl")
 
 export Descent, ADAM, Momentum, Nesterov, RMSProp,
        ADAGrad, AdaMax, ADADelta, AMSGrad, NADAM, ADAMW, RADAM, OADAM, AdaBelief,
-       WeightDecay, ChainOptimiser
+       WeightDecay, OptimiserChain
 
 end # module

--- a/src/Optimisers.jl
+++ b/src/Optimisers.jl
@@ -7,6 +7,6 @@ include("rules.jl")
 
 export Descent, ADAM, Momentum, Nesterov, RMSProp,
        ADAGrad, AdaMax, ADADelta, AMSGrad, NADAM, ADAMW, RADAM, OADAM, AdaBelief,
-       WeightDecay, Sequence
+       WeightDecay, SequenceOptimiser
 
 end # module

--- a/src/Optimisers.jl
+++ b/src/Optimisers.jl
@@ -6,7 +6,8 @@ include("interface.jl")
 include("rules.jl")
 
 export init, update!
-export Descent, Momentum, Nesterov, RMSProp,
-       ADAM
+export Descent, ADAM, Momentum, Nesterov, RMSProp,
+       ADAGrad, AdaMax, ADADelta, AMSGrad, NADAM, ADAMW, RADAM, OADAM, AdaBelief,
+       WeightDecay, Sequence
 
 end # module

--- a/src/Optimisers.jl
+++ b/src/Optimisers.jl
@@ -5,7 +5,6 @@ using Functors: functor, fmap, isleaf
 include("interface.jl")
 include("rules.jl")
 
-export init, update!
 export Descent, ADAM, Momentum, Nesterov, RMSProp,
        ADAGrad, AdaMax, ADADelta, AMSGrad, NADAM, ADAMW, RADAM, OADAM, AdaBelief,
        WeightDecay, Sequence

--- a/src/Optimisers.jl
+++ b/src/Optimisers.jl
@@ -7,6 +7,6 @@ include("rules.jl")
 
 export Descent, ADAM, Momentum, Nesterov, RMSProp,
        ADAGrad, AdaMax, ADADelta, AMSGrad, NADAM, ADAMW, RADAM, OADAM, AdaBelief,
-       WeightDecay, SequenceOptimiser
+       WeightDecay, ChainOptimiser
 
 end # module

--- a/src/Optimisers.jl
+++ b/src/Optimisers.jl
@@ -5,6 +5,7 @@ using Functors: functor, fmap, isleaf
 include("interface.jl")
 include("rules.jl")
 
+export init, update!
 export Descent, Momentum, Nesterov, RMSProp,
        ADAM
 

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -13,7 +13,7 @@ function init(o, x)
 end
 
 function _update!(o, x, x̄, st)
-  x̄, st = apply!(o, x̄, st)
+  x̄, st = apply!(o, x, x̄, st)
   return patch!(x, x̄), st
 end
 

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -1,7 +1,4 @@
-function patch!(x, x̄)
-  @. x .-= x̄
-  return x
-end
+patch(x, x̄) = x .- x̄
 
 function init(o, x)
   if isleaf(x)
@@ -12,20 +9,20 @@ function init(o, x)
   end
 end
 
-function _update!(o, x, x̄, st)
-  x̄, st = apply!(o, x, x̄, st)
-  return patch!(x, x̄), st
+function _update(o, x, x̄, st)
+  x̄, st = apply(o, x, x̄, st)
+  return patch(x, x̄), st
 end
 
-function update!(o, x::T, x̄, state) where T
+function update(o, x::T, x̄, state) where T
   if x̄ === nothing
     return x, state
   elseif isleaf(x)
-    _update!(o, x, x̄, state)
+    _update(o, x, x̄, state)
   else
     x̄, _  = functor(typeof(x), x̄)
     x, restructure = functor(typeof(x), x)
-    xstate = map((x, x̄, state) -> update!(o, x, x̄, state), x, x̄, state)
+    xstate = map((x, x̄, state) -> update(o, x, x̄, state), x, x̄, state)
     restructure(map(first, xstate)), map(x -> x[2], xstate)
   end
 end

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -1,11 +1,11 @@
 patch(x, x̄) = x .- x̄
 
-function init(o, x)
+function state(o, x)
   if isleaf(x)
     return init(o, x)
   else
     x, _ = functor(x)
-    return map(x -> init(o, x), x)
+    return map(x -> state(o, x), x)
   end
 end
 
@@ -18,11 +18,11 @@ function update(o, x::T, x̄, state) where T
   if x̄ === nothing
     return x, state
   elseif isleaf(x)
-    _update(o, x, x̄, state)
+    return _update(o, x, x̄, state)
   else
     x̄, _  = functor(typeof(x), x̄)
     x, restructure = functor(typeof(x), x)
     xstate = map((x, x̄, state) -> update(o, x, x̄, state), x, x̄, state)
-    restructure(map(first, xstate)), map(x -> x[2], xstate)
+    return restructure(map(first, xstate)), map(x -> x[2], xstate)
   end
 end

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -1,30 +1,31 @@
-function patch(x, x̄)
-  return x .- x̄
+function patch!(x, x̄)
+  @. x .-= x̄
+  return x
 end
 
-function state(o, x)
+function init(o, x)
   if isleaf(x)
     return init(o, x)
   else
     x, _ = functor(x)
-    map(x -> state(o, x), x)
+    return map(x -> init(o, x), x)
   end
 end
 
-function _update(o, x, x̄, st)
-  x̄, st = apply(o, x, x̄, st)
-  return patch(x, x̄), st
+function _update!(o, x, x̄, st)
+  x̄, st = apply!(o, x̄, st)
+  return patch!(x, x̄), st
 end
 
-function update(o, x::T, x̄, state) where T
+function update!(o, x::T, x̄, state) where T
   if x̄ === nothing
     return x, state
   elseif isleaf(x)
-    _update(o, x, x̄, state)
+    _update!(o, x, x̄, state)
   else
     x̄, _  = functor(typeof(x), x̄)
-    x, re = functor(typeof(x), x)
-    xstate = map((x, x̄, state) -> update(o, x, x̄, state), x, x̄, state)
-    re(map(first, xstate)), map(x -> x[2], xstate)
+    x, restructure = functor(typeof(x), x)
+    xstate = map((x, x̄, state) -> update!(o, x, x̄, state), x, x̄, state)
+    restructure(map(first, xstate)), map(x -> x[2], xstate)
   end
 end

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -430,7 +430,7 @@ weight decay regularization.
                          (no need to change default)
 """
 ADAMW(η = 1f-3, β = (9f-1, 9.99f-1), γ = 0, ϵ = eps(typeof(η))) =
-  SequenceOptimiser(ADAM(η, β, ϵ), WeightDecay(γ))
+  ChainOptimiser(ADAM(η, β, ϵ), WeightDecay(γ))
 
 """
     AdaBelief(η = 1f-3, β = (9f-1, 9.99f-1), ϵ = eps(typeof(η)))

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -1,5 +1,5 @@
 """
-    Descent(; η = 0.1)
+    Descent(η = 0.1)
 
 Classic gradient descent optimiser with learning rate `η`.
 For each parameter `p` and its gradient `dp`, this runs `p -= η*dp`.
@@ -11,7 +11,7 @@ For each parameter `p` and its gradient `dp`, this runs `p -= η*dp`.
 struct Descent{T}
   eta::T
 end
-Descent(; η = 0.1) = Descent(η)
+Descent(η = 0.1) = Descent(η)
 
 init(o::Descent, x::AbstractArray) = nothing
 
@@ -25,7 +25,7 @@ end
 (o::Descent)(m, dm, st) = update(o, m, dm, st)
 
 """
-    Momentum(; η = 0.01, ρ = 0.9)
+    Momentum(η = 0.01, ρ = 0.9)
 
 Gradient descent optimizer with learning rate `η` and momentum `ρ`.
 
@@ -39,7 +39,7 @@ struct Momentum{T}
   eta::T
   rho::T
 end
-Momentum(; η = 0.01, ρ = 0.9) = Momentum(η, ρ)
+Momentum(η = 0.01, ρ = 0.9) = Momentum(η, ρ)
 
 init(o::Momentum, x::AbstractArray) = (velocity = zero(x),)
 
@@ -53,7 +53,7 @@ end
 (o::Momentum)(m, dm, state) = update(o, m, dm, state)
 
 """
-    Nesterov(; η = 0.001, ρ = 0.9)
+    Nesterov(η = 0.001, ρ = 0.9)
 
 Gradient descent optimizer with learning rate `η` and Nesterov momentum `ρ`.
 
@@ -67,7 +67,7 @@ struct Nesterov{T}
   eta::T
   rho::T
 end
-Nesterov(; η = 0.001, ρ = 0.9) = Nesterov(η, ρ)
+Nesterov(η = 0.001, ρ = 0.9) = Nesterov(η, ρ)
 
 init(o::Nesterov, x::AbstractArray) = (velocity = zero(x),)
 
@@ -82,7 +82,7 @@ function apply(o::Nesterov, x, dx, state)
 end
 
 """
-    RMSProp(; η = 0.001, ρ = 0.9, ϵ = eps(typeof(η)))
+    RMSProp(η = 0.001, ρ = 0.9, ϵ = eps(typeof(η)))
 
 Optimizer using the
 [RMSProp](https://www.cs.toronto.edu/~tijmen/csc321/slides/lecture_slides_lec6.pdf)
@@ -102,7 +102,7 @@ struct RMSProp{T}
   rho::T
   epsilon::T
 end
-RMSProp(; η = 0.001, ρ = 0.9, ϵ = eps(typeof(η))) = RMSProp(η, ρ, ϵ)
+RMSProp(η = 0.001, ρ = 0.9, ϵ = eps(typeof(η))) = RMSProp(η, ρ, ϵ)
 
 init(o::RMSProp, x::AbstractArray) = (acceleration = zero(x),)
 
@@ -117,7 +117,7 @@ end
 (o::RMSProp)(m, dm, state) = update(o, m, dm, state)
 
 """
-    ADAM(; η = 0.001, β = (0.9, 0.999), ϵ = eps(typeof(η)))
+    ADAM(η = 0.001, β = (0.9, 0.999), ϵ = eps(typeof(η)))
 
 [ADAM](https://arxiv.org/abs/1412.6980) optimiser.
 
@@ -134,7 +134,7 @@ struct ADAM{T}
   beta::Tuple{T, T}
   epsilon::T
 end
-ADAM(; η = 0.001, β = (0.9, 0.999), ϵ = eps(typeof(η))) = ADAM(η, β, ϵ)
+ADAM(η = 0.001, β = (0.9, 0.999), ϵ = eps(typeof(η))) = ADAM(η, β, ϵ)
 
 init(o::ADAM, x::AbstractArray) = (moments = (zero(x), zero(x)), decays = o.beta)
 
@@ -152,7 +152,7 @@ function apply(o::ADAM{T}, x, dx, state) where T
 end
 
 """
-    RADAM(; η = 0.001, β = (0.9, 0.999), ϵ = eps(typeof(η)))
+    RADAM(η = 0.001, β = (0.9, 0.999), ϵ = eps(typeof(η)))
 
 [Rectified ADAM](https://arxiv.org/abs/1908.03265) optimizer.
 
@@ -169,7 +169,7 @@ struct RADAM{T}
   beta::Tuple{T, T}
   epsilon::T
 end
-RADAM(; η = 0.001, β = (0.9, 0.999), ϵ = eps(typeof(η))) = RADAM(η, β, ϵ)
+RADAM(η = 0.001, β = (0.9, 0.999), ϵ = eps(typeof(η))) = RADAM(η, β, ϵ)
 
 init(o::RADAM, x::AbstractArray) = (moments = (zero(x), zero(x)), decays = o.beta, t = 1)
 
@@ -196,7 +196,7 @@ function apply(o::RADAM, x, dx, state)
 end
 
 """
-    AdaMax(; η = 0.001, β = (0.9, 0.999), ϵ = eps(typeof(η)))
+    AdaMax(η = 0.001, β = (0.9, 0.999), ϵ = eps(typeof(η)))
 
 [AdaMax](https://arxiv.org/abs/1412.6980) is a variant of ADAM based on the ∞-norm.
 
@@ -213,7 +213,7 @@ struct AdaMax{T}
   beta::Tuple{T, T}
   epsilon::T
 end
-AdaMax(; η = 0.001, β = (0.9, 0.999), ϵ = eps(typeof(η))) = AdaMax(η, β, ϵ)
+AdaMax(η = 0.001, β = (0.9, 0.999), ϵ = eps(typeof(η))) = AdaMax(η, β, ϵ)
 
 init(o::AdaMax, x::AbstractArray) = (moments = (zero(x), zero(x)), decays = o.beta)
 
@@ -233,7 +233,7 @@ function apply(o::AdaMax, x, dx, state)
 end
 
 """
-    OADAM(; η = 0.001, β = (0.5, 0.9), ϵ = eps(typeof(η)))
+    OADAM(η = 0.001, β = (0.5, 0.9), ϵ = eps(typeof(η)))
 
 [OADAM](https://arxiv.org/abs/1711.00141) (Optimistic ADAM)
 is a variant of ADAM adding an "optimistic" term suitable for adversarial training.
@@ -251,7 +251,7 @@ struct OADAM{T}
   beta::Tuple{T, T}
   epsilon::T
 end
-OADAM(; η = 0.001, β = (0.5, 0.9), ϵ = eps(typeof(η))) = OADAM(η, β, ϵ)
+OADAM(η = 0.001, β = (0.5, 0.9), ϵ = eps(typeof(η))) = OADAM(η, β, ϵ)
 
 init(o::OADAM, x::AbstractArray) = (moments = (zero(x), zero(x)), decays = o.beta, dx = zero(x))
 
@@ -273,7 +273,7 @@ function apply(o::OADAM, x, dx, state)
 end
 
 """
-    ADAGrad(; η = 0.1, ϵ = eps(typeof(η)))
+    ADAGrad(η = 0.1, ϵ = eps(typeof(η)))
 
 [ADAGrad](http://www.jmlr.org/papers/volume12/duchi11a/duchi11a.pdf) optimizer. It has
 parameter specific learning rates based on how frequently it is updated.
@@ -289,7 +289,7 @@ struct ADAGrad{T}
   eta::T
   epsilon::T
 end
-ADAGrad(; η = 0.1, ϵ = eps(typeof(η))) = ADAGrad(η, ϵ)
+ADAGrad(η = 0.1, ϵ = eps(typeof(η))) = ADAGrad(η, ϵ)
 
 init(o::ADAGrad, x::AbstractArray) = (acceleration = fill!(similar(x), o.epsilon),)
 
@@ -306,7 +306,7 @@ function apply(o::ADAGrad, x, dx, state)
 end
 
 """
-    ADADelta(; ρ = 0.9, ϵ = eps(typeof(ρ)))
+    ADADelta(ρ = 0.9, ϵ = eps(typeof(ρ)))
 
 [ADADelta](https://arxiv.org/abs/1212.5701) is a version of ADAGrad adapting its learning
 rate based on a window of past gradient updates.
@@ -321,7 +321,7 @@ struct ADADelta{T}
   rho::T
   epsilon::T
 end
-ADADelta(; ρ = 0.9, ϵ = eps(typeof(ρ))) = ADADelta(ρ, ϵ)
+ADADelta(ρ = 0.9, ϵ = eps(typeof(ρ))) = ADADelta(ρ, ϵ)
 
 init(o::ADADelta, x::AbstractArray) = (acceleration = zero(x), Δacceleration = zero(x))
 
@@ -341,7 +341,7 @@ function apply(o::ADADelta, x, dx, state)
 end
 
 """
-    AMSGrad(; η = 0.001, β = (0.9, 0.999), ϵ = eps(typeof(η)))
+    AMSGrad(η = 0.001, β = (0.9, 0.999), ϵ = eps(typeof(η)))
 
 The [AMSGrad](https://openreview.net/forum?id=ryQu7f-RZ) version of the ADAM
 optimiser. Parameters don't need tuning.
@@ -359,7 +359,7 @@ struct AMSGrad{T}
   beta::Tuple{T, T}
   epsilon::T
 end
-AMSGrad(; η = 0.001, β = (0.9, 0.999), ϵ = eps(typeof(η))) = AMSGrad(η, β, ϵ)
+AMSGrad(η = 0.001, β = (0.9, 0.999), ϵ = eps(typeof(η))) = AMSGrad(η, β, ϵ)
 
 init(o::AMSGrad, x::AbstractArray) =
   (moments = (fill!(similar(x), o.epsilon), fill!(similar(x), o.epsilon), fill!(similar(x), o.epsilon)),)
@@ -380,7 +380,7 @@ function apply(o::AMSGrad, x, dx, state)
 end
 
 """
-    NADAM(; η = 0.001, β = (0.9, 0.999), ϵ = eps(typeof(η)))
+    NADAM(η = 0.001, β = (0.9, 0.999), ϵ = eps(typeof(η)))
 
 [NADAM](https://openreview.net/forum?id=OM0jvwB8jIp57ZJjtNEZ) is a Nesterov variant of ADAM.
 Parameters don't need tuning.
@@ -398,7 +398,7 @@ struct NADAM{T}
   beta::Tuple{T, T}
   epsilon::T
 end
-NADAM(; η = 0.001, β = (0.9, 0.999), ϵ = eps(typeof(η))) = NADAM(η, β, ϵ)
+NADAM(η = 0.001, β = (0.9, 0.999), ϵ = eps(typeof(η))) = NADAM(η, β, ϵ)
 
 init(o::NADAM, x::AbstractArray) = (moments = (zero(x), zero(x)), decays = o.beta)
 
@@ -419,7 +419,7 @@ function apply(o::NADAM, x, dx, state)
 end
 
 """
-    ADAMW(; η = 0.001, β = (0.9, 0.999), γ = 0, ϵ = eps(typeof(η)))
+    ADAMW(η = 0.001, β = (0.9, 0.999), γ = 0, ϵ = eps(typeof(η)))
 
 [ADAMW](https://arxiv.org/abs/1711.05101) is a variant of ADAM fixing (as in repairing) its
 weight decay regularization.
@@ -433,11 +433,11 @@ weight decay regularization.
 - Machine epsilon (`ϵ`): Constant to prevent division by zero
                          (no need to change default)
 """
-ADAMW(; η = 0.001, β = (0.9, 0.999), γ = 0, ϵ = eps(typeof(η))) =
+ADAMW(η = 0.001, β = (0.9, 0.999), γ = 0, ϵ = eps(typeof(η))) =
   SequenceOptimiser(ADAM(η, β, ϵ), WeightDecay(γ))
 
 """
-    AdaBelief(; η = 0.001, β = (0.9, 0.999), ϵ = eps(typeof(η)))
+    AdaBelief(η = 0.001, β = (0.9, 0.999), ϵ = eps(typeof(η)))
 
 The [AdaBelief](https://arxiv.org/abs/2010.07468) optimiser is a variant of the well-known
 ADAM optimiser.
@@ -455,7 +455,7 @@ struct AdaBelief{T}
   beta::Tuple{T, T}
   epsilon::T
 end
-AdaBelief(; η = 0.001, β = (0.9, 0.999), ϵ = eps(typeof(η))) = AdaBelief(η, β, ϵ)
+AdaBelief(η = 0.001, β = (0.9, 0.999), ϵ = eps(typeof(η))) = AdaBelief(η, β, ϵ)
 
 init(o::AdaBelief, x::AbstractArray) = (moments = (zero(x), zero(x)),)
 
@@ -473,7 +473,7 @@ function apply(o::AdaBelief, x, dx, state)
 end
 
 """
-    WeightDecay(; γ = 0)
+    WeightDecay(γ = 0)
 
 Decay weights by `γ`.
 
@@ -483,7 +483,7 @@ Decay weights by `γ`.
 struct WeightDecay{T}
   wd::T
 end
-WeightDecay(; γ = 1e-4) = WeightDecay(γ)
+WeightDecay(γ = 1e-4) = WeightDecay(γ)
 
 init(o::WeightDecay, x::AbstractArray) = nothing
 

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -1,5 +1,3 @@
-const mach_eps = 1f-8
-
 """
     Descent(; η = 0.1)
 
@@ -37,9 +35,9 @@ Gradient descent optimizer with learning rate `η` and momentum `ρ`.
 - Momentum (`ρ`): Controls the acceleration of gradient descent in the
                   prominent direction, in effect dampening oscillations.
 """
-struct Momentum{T,S}
+struct Momentum{T}
   eta::T
-  rho::S
+  rho::T
 end
 Momentum(; η = 0.01, ρ = 0.9) = Momentum(η, ρ)
 
@@ -65,9 +63,9 @@ Gradient descent optimizer with learning rate `η` and Nesterov momentum `ρ`.
 - Nesterov momentum (`ρ`): Controls the acceleration of gradient descent in the
                            prominent direction, in effect dampening oscillations.
 """
-struct Nesterov{T,S}
+struct Nesterov{T}
   eta::T
-  rho::S
+  rho::T
 end
 Nesterov(; η = 0.001, ρ = 0.9) = Nesterov(η, ρ)
 
@@ -84,7 +82,7 @@ function apply(o::Nesterov, x, dx, state)
 end
 
 """
-    RMSProp(; η = 0.001, ρ = 0.9, ϵ = 1f-8)
+    RMSProp(; η = 0.001, ρ = 0.9, ϵ = eps(typeof(η)))
 
 Optimizer using the
 [RMSProp](https://www.cs.toronto.edu/~tijmen/csc321/slides/lecture_slides_lec6.pdf)
@@ -96,15 +94,15 @@ generally don't need tuning.
                        the weights.
 - Momentum (`ρ`): Controls the acceleration of gradient descent in the
                   prominent direction, in effect dampening oscillations.
-- Machine epsilon (`ϵ::Float32`): Constant to prevent division by zero
-                  (no need to change default)
+- Machine epsilon (`ϵ`): Constant to prevent division by zero
+                         (no need to change default)
 """
-struct RMSProp{T,S}
+struct RMSProp{T}
   eta::T
-  rho::S
-  epsilon::Float32
+  rho::T
+  epsilon::T
 end
-RMSProp(; η = 0.001, ρ = 0.9, ϵ = mach_eps) = RMSProp(η, ρ, ϵ)
+RMSProp(; η = 0.001, ρ = 0.9, ϵ = eps(typeof(η))) = RMSProp(η, ρ, ϵ)
 
 init(o::RMSProp, x::AbstractArray) = (acceleration = zero(x),)
 
@@ -119,7 +117,7 @@ end
 (o::RMSProp)(m, dm, state) = update(o, m, dm, state)
 
 """
-    ADAM(; η = 0.001, β = (0.9, 0.999), ϵ = 1f-8)
+    ADAM(; η = 0.001, β = (0.9, 0.999), ϵ = eps(typeof(η)))
 
 [ADAM](https://arxiv.org/abs/1412.6980) optimiser.
 
@@ -128,15 +126,15 @@ end
                        the weights.
 - Decay of momentums (`β::Tuple`): Exponential decay for the first (β1) and the
                                    second (β2) momentum estimate.
-- Machine epsilon (`ϵ::Float32`): Constant to prevent division by zero
-                                  (no need to change default)
+- Machine epsilon (`ϵ`): Constant to prevent division by zero
+                         (no need to change default)
 """
-struct ADAM{T,K}
+struct ADAM{T}
   eta::T
-  beta::Tuple{K,K}
-  epsilon::Float32
+  beta::Tuple{T, T}
+  epsilon::T
 end
-ADAM(; η = 0.001, β = (0.9, 0.999), ϵ = mach_eps) = ADAM(η, β, ϵ)
+ADAM(; η = 0.001, β = (0.9, 0.999), ϵ = eps(typeof(η))) = ADAM(η, β, ϵ)
 
 init(o::ADAM, x::AbstractArray) = (moments = (zero(x), zero(x)), decays = o.beta)
 
@@ -154,7 +152,7 @@ function apply(o::ADAM{T}, x, dx, state) where T
 end
 
 """
-    RADAM(; η = 0.001, β = (0.9, 0.999), ϵ = mach_eps)
+    RADAM(; η = 0.001, β = (0.9, 0.999), ϵ = eps(typeof(η)))
 
 [Rectified ADAM](https://arxiv.org/abs/1908.03265) optimizer.
 
@@ -163,15 +161,15 @@ end
                        the weights.
 - Decay of momentums (`β::Tuple`): Exponential decay for the first (β1) and the
                                    second (β2) momentum estimate.
-- Machine epsilon (`ϵ::Float32`): Constant to prevent division by zero
-                                  (no need to change default)
+- Machine epsilon (`ϵ`): Constant to prevent division by zero
+                         (no need to change default)
 """
-struct RADAM{T,S}
+struct RADAM{T}
   eta::T
-  beta::Tuple{S,S}
-  epsilon::Float32
+  beta::Tuple{T, T}
+  epsilon::T
 end
-RADAM(; η = 0.001, β = (0.9, 0.999), ϵ = mach_eps) = RADAM(η, β, ϵ)
+RADAM(; η = 0.001, β = (0.9, 0.999), ϵ = eps(typeof(η))) = RADAM(η, β, ϵ)
 
 init(o::RADAM, x::AbstractArray) = (moments = (zero(x), zero(x)), decays = o.beta, t = 1)
 
@@ -198,7 +196,7 @@ function apply(o::RADAM, x, dx, state)
 end
 
 """
-    AdaMax(; η = 0.001, β = (0.9, 0.999), ϵ = 1f-8)
+    AdaMax(; η = 0.001, β = (0.9, 0.999), ϵ = eps(typeof(η)))
 
 [AdaMax](https://arxiv.org/abs/1412.6980) is a variant of ADAM based on the ∞-norm.
 
@@ -207,15 +205,15 @@ end
                        the weights.
 - Decay of momentums (`β::Tuple`): Exponential decay for the first (β1) and the
                                    second (β2) momentum estimate.
-- Machine epsilon (`ϵ::Float32`): Constant to prevent division by zero
-                                  (no need to change default)
+- Machine epsilon (`ϵ`): Constant to prevent division by zero
+                         (no need to change default)
 """
-struct AdaMax{T,S}
+struct AdaMax{T}
   eta::T
-  beta::Tuple{S,S}
-  epsilon::Float32
+  beta::Tuple{T, T}
+  epsilon::T
 end
-AdaMax(; η = 0.001, β = (0.9, 0.999), ϵ = 1f-8) = AdaMax(η, β, ϵ)
+AdaMax(; η = 0.001, β = (0.9, 0.999), ϵ = eps(typeof(η))) = AdaMax(η, β, ϵ)
 
 init(o::AdaMax, x::AbstractArray) = (moments = (zero(x), zero(x)), decays = o.beta)
 
@@ -235,7 +233,7 @@ function apply(o::AdaMax, x, dx, state)
 end
 
 """
-    OADAM(; η = 0.001, β = (0.5, 0.9), ϵ = 1f-8)
+    OADAM(; η = 0.001, β = (0.5, 0.9), ϵ = eps(typeof(η)))
 
 [OADAM](https://arxiv.org/abs/1711.00141) (Optimistic ADAM)
 is a variant of ADAM adding an "optimistic" term suitable for adversarial training.
@@ -245,15 +243,15 @@ is a variant of ADAM adding an "optimistic" term suitable for adversarial traini
                        the weights.
 - Decay of momentums (`β::Tuple`): Exponential decay for the first (β1) and the
                                    second (β2) momentum estimate.
-- Machine epsilon (`ϵ::Float32`): Constant to prevent division by zero
-                                  (no need to change default)
+- Machine epsilon (`ϵ`): Constant to prevent division by zero
+                         (no need to change default)
 """
-struct OADAM{T,S}
+struct OADAM{T}
   eta::T
-  beta::Tuple{S,S}
-  epsilon::Float32
+  beta::Tuple{T, T}
+  epsilon::T
 end
-OADAM(; η = 0.001, β = (0.5, 0.9), ϵ = mach_eps) = OADAM(η, β, ϵ)
+OADAM(; η = 0.001, β = (0.5, 0.9), ϵ = eps(typeof(η))) = OADAM(η, β, ϵ)
 
 init(o::OADAM, x::AbstractArray) = (moments = (zero(x), zero(x)), decays = o.beta, dx = zero(x))
 
@@ -275,7 +273,7 @@ function apply(o::OADAM, x, dx, state)
 end
 
 """
-    ADAGrad(; η = 0.1, ϵ = 1f-8)
+    ADAGrad(; η = 0.1, ϵ = eps(typeof(η)))
 
 [ADAGrad](http://www.jmlr.org/papers/volume12/duchi11a/duchi11a.pdf) optimizer. It has
 parameter specific learning rates based on how frequently it is updated.
@@ -284,14 +282,14 @@ Parameters don't need tuning.
 # Parameters
 - Learning rate (`η`): Amount by which gradients are discounted before updating
                        the weights.
-- Machine epsilon (`ϵ::Float32`): Constant to prevent division by zero
-                                  (no need to change default)
+- Machine epsilon (`ϵ`): Constant to prevent division by zero
+                         (no need to change default)
 """
 struct ADAGrad{T}
   eta::T
-  epsilon::Float32
+  epsilon::T
 end
-ADAGrad(; η = 0.1, ϵ = mach_eps) = ADAGrad(η, ϵ)
+ADAGrad(; η = 0.1, ϵ = eps(typeof(η))) = ADAGrad(η, ϵ)
 
 init(o::ADAGrad, x::AbstractArray) = (acceleration = fill!(similar(x), o.epsilon),)
 
@@ -308,7 +306,7 @@ function apply(o::ADAGrad, x, dx, state)
 end
 
 """
-    ADADelta(; ρ = 0.9, ϵ = 1f-8)
+    ADADelta(; ρ = 0.9, ϵ = eps(typeof(ρ)))
 
 [ADADelta](https://arxiv.org/abs/1212.5701) is a version of ADAGrad adapting its learning
 rate based on a window of past gradient updates.
@@ -316,14 +314,14 @@ Parameters don't need tuning.
 
 # Parameters
 - Rho (`ρ`): Factor by which the gradient is decayed at each time step.
-- Machine epsilon (`ϵ::Float32`): Constant to prevent division by zero
-                                  (no need to change default)
+- Machine epsilon (`ϵ`): Constant to prevent division by zero
+                         (no need to change default)
 """
 struct ADADelta{T}
   rho::T
-  epsilon::Float32
+  epsilon::T
 end
-ADADelta(; ρ = 0.9, ϵ = mach_eps) = ADADelta(ρ, ϵ)
+ADADelta(; ρ = 0.9, ϵ = eps(typeof(ρ))) = ADADelta(ρ, ϵ)
 
 init(o::ADADelta, x::AbstractArray) = (acceleration = zero(x), Δacceleration = zero(x))
 
@@ -343,7 +341,7 @@ function apply(o::ADADelta, x, dx, state)
 end
 
 """
-    AMSGrad(; η = 0.001, β = (0.9, 0.999), ϵ = 1f-8)
+    AMSGrad(; η = 0.001, β = (0.9, 0.999), ϵ = eps(typeof(η)))
 
 The [AMSGrad](https://openreview.net/forum?id=ryQu7f-RZ) version of the ADAM
 optimiser. Parameters don't need tuning.
@@ -353,15 +351,15 @@ optimiser. Parameters don't need tuning.
                        the weights.
 - Decay of momentums (`β::Tuple`): Exponential decay for the first (β1) and the
                                    second (β2) momentum estimate.
-- Machine epsilon (`ϵ::Float32`): Constant to prevent division by zero
-                                  (no need to change default)
+- Machine epsilon (`ϵ`): Constant to prevent division by zero
+                         (no need to change default)
 """
-struct AMSGrad{T,S}
+struct AMSGrad{T}
   eta::T
-  beta::Tuple{S,S}
-  epsilon::Float32
+  beta::Tuple{T, T}
+  epsilon::T
 end
-AMSGrad(; η = 0.001, β = (0.9, 0.999), ϵ = mach_eps) = AMSGrad(η, β, ϵ)
+AMSGrad(; η = 0.001, β = (0.9, 0.999), ϵ = eps(typeof(η))) = AMSGrad(η, β, ϵ)
 
 init(o::AMSGrad, x::AbstractArray) =
   (moments = (fill!(similar(x), o.epsilon), fill!(similar(x), o.epsilon), fill!(similar(x), o.epsilon)),)
@@ -382,7 +380,7 @@ function apply(o::AMSGrad, x, dx, state)
 end
 
 """
-    NADAM(; η = 0.001, β = (0.9, 0.999), ϵ = 1f-8)
+    NADAM(; η = 0.001, β = (0.9, 0.999), ϵ = eps(typeof(η)))
 
 [NADAM](https://openreview.net/forum?id=OM0jvwB8jIp57ZJjtNEZ) is a Nesterov variant of ADAM.
 Parameters don't need tuning.
@@ -392,15 +390,15 @@ Parameters don't need tuning.
                        the weights.
 - Decay of momentums (`β::Tuple`): Exponential decay for the first (β1) and the
                                    second (β2) momentum estimate.
-- Machine epsilon (`ϵ::Float32`): Constant to prevent division by zero
-                                  (no need to change default)
+- Machine epsilon (`ϵ`): Constant to prevent division by zero
+                         (no need to change default)
 """
-struct NADAM{T,S}
+struct NADAM{T}
   eta::T
-  beta::Tuple{S,S}
-  epsilon::Float32
+  beta::Tuple{T, T}
+  epsilon::T
 end
-NADAM(; η = 0.001, β = (0.9, 0.999), ϵ = mach_eps) = NADAM(η, β, ϵ)
+NADAM(; η = 0.001, β = (0.9, 0.999), ϵ = eps(typeof(η))) = NADAM(η, β, ϵ)
 
 init(o::NADAM, x::AbstractArray) = (moments = (zero(x), zero(x)), decays = o.beta)
 
@@ -421,7 +419,7 @@ function apply(o::NADAM, x, dx, state)
 end
 
 """
-    ADAMW(; η = 0.001, β = (0.9, 0.999), γ = 0, ϵ = 1f-8)
+    ADAMW(; η = 0.001, β = (0.9, 0.999), γ = 0, ϵ = eps(typeof(η)))
 
 [ADAMW](https://arxiv.org/abs/1711.05101) is a variant of ADAM fixing (as in repairing) its
 weight decay regularization.
@@ -431,15 +429,15 @@ weight decay regularization.
                        the weights.
 - Decay of momentums (`β::Tuple`): Exponential decay for the first (β1) and the
                                    second (β2) momentum estimate.
-- `γ`: Decay applied to weights during optimisation.
-- Machine epsilon (`ϵ::Float32`): Constant to prevent division by zero
-                                  (no need to change default)
+- Weight decay (`γ`): Decay applied to weights during optimisation.
+- Machine epsilon (`ϵ`): Constant to prevent division by zero
+                         (no need to change default)
 """
-ADAMW(; η = 0.001, β = (0.9, 0.999), γ = 0, ϵ = mach_eps) =
+ADAMW(; η = 0.001, β = (0.9, 0.999), γ = 0, ϵ = eps(typeof(η))) =
   SequenceOptimiser(ADAM(η, β, ϵ), WeightDecay(γ))
 
 """
-    AdaBelief(;η = 0.001, β = (0.9, 0.999), ϵ = 1f-8)
+    AdaBelief(; η = 0.001, β = (0.9, 0.999), ϵ = eps(typeof(η)))
 
 The [AdaBelief](https://arxiv.org/abs/2010.07468) optimiser is a variant of the well-known
 ADAM optimiser.
@@ -452,12 +450,12 @@ ADAM optimiser.
 - Machine epsilon (`ϵ::Float32`): Constant to prevent division by zero
                                   (no need to change default)
 """
-struct AdaBelief{T,S}
+struct AdaBelief{T}
   eta::T
-  beta::Tuple{S,S}
-  epsilon::Float32
+  beta::Tuple{T, T}
+  epsilon::T
 end
-AdaBelief(; η = 0.001, β = (0.9, 0.999), ϵ = mach_eps) = AdaBelief(η, β, ϵ)
+AdaBelief(; η = 0.001, β = (0.9, 0.999), ϵ = eps(typeof(η))) = AdaBelief(η, β, ϵ)
 
 init(o::AdaBelief, x::AbstractArray) = (moments = (zero(x), zero(x)),)
 
@@ -477,10 +475,10 @@ end
 """
     WeightDecay(; γ = 0)
 
-Decay weights by `wd`.
+Decay weights by `γ`.
 
 # Parameters
-- Weight decay (`γ`)
+- Weight decay (`γ`): Decay applied to weights during optimisation.
 """
 struct WeightDecay{T}
   wd::T

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -1,3 +1,5 @@
+const mach_eps = 1f-8
+
 """
     Descent(;η = 0.1)
 
@@ -15,7 +17,7 @@ Descent(;η = 0.1) = Descent(η)
 
 init(o::Descent, x::AbstractArray) = nothing
 
-function apply!(o::Descent, dx, state)
+function apply!(o::Descent, x, dx, state)
   η = convert(eltype(dx), o.eta)
   dx .*= η
   
@@ -43,7 +45,7 @@ Momentum(;η = 0.01, ρ = 0.9) = Momentum(η, ρ)
 
 init(o::Momentum, x::AbstractArray) = (velocity = zero(x),)
 
-function apply!(o::Momentum, dx, state)
+function apply!(o::Momentum, x, dx, state)
   η, ρ, v = o.eta, o.rho, state.velocity
   @. v = ρ * v - η * dx
   @. dx = -v
@@ -74,7 +76,7 @@ init(o::Nesterov, x::AbstractArray) = (velocity = zero(x),)
 
 (o::Nesterov)(m, dm, state) = update!(o, m, dm, state)
 
-function apply!(o::Nesterov, dx, state)
+function apply!(o::Nesterov, x, dx, state)
   η, ρ, v = o.eta, o.rho, state.velocity
   d = @. ρ^2 * v - (1+ρ) * η * dx
   @. v = ρ * v - η * dx
@@ -104,11 +106,11 @@ mutable struct RMSProp{T,S}
   rho::S
   epsilon::Float32
 end
-RMSProp(;η = 0.001, ρ = 0.9, ϵ = 1f-8) = RMSProp(η, ρ, ϵ)
+RMSProp(;η = 0.001, ρ = 0.9, ϵ = mach_eps) = RMSProp(η, ρ, ϵ)
 
 init(o::RMSProp, x::AbstractArray) = (acceleration = zero(x),)
 
-function apply!(o::RMSProp, dx, state)
+function apply!(o::RMSProp, x, dx, state)
   η, ρ, ϵ, acc = o.eta, o.rho, o.epsilon, state.acceleration
   @. acc = ρ * acc + (1 - ρ) * dx^2
   @. dx = dx * (η / (sqrt(acc) + ϵ))
@@ -136,17 +138,386 @@ mutable struct ADAM{T,K}
   beta::Tuple{K,K}
   epsilon::Float32
 end
-ADAM(;η = 0.001, β = (0.9, 0.999), ϵ = 1f-8) = ADAM(η, β, ϵ)
+ADAM(;η = 0.001, β = (0.9, 0.999), ϵ = mach_eps) = ADAM(η, β, ϵ)
 
 init(o::ADAM, x::AbstractArray) = (moments = (zero(x), zero(x)), decays = o.beta)
 
 (o::ADAM)(m, dm, state) = update!(o, m, dm, state)
 
-function apply!(o::ADAM{T}, dx, state) where T
+function apply!(o::ADAM{T}, x, dx, state) where T
   η, β, βt, ϵ = o.eta, o.beta, state.decays, o.epsilon
   mt, vt = state.moments
+
   @. mt = β[1] * mt + (one(T) - β[1]) * dx
   @. vt = β[2] * vt + (one(T) - β[2]) * dx ^ 2
   @. dx =  mt / (one(T) - βt[1]) / (sqrt(vt / (one(T) - βt[2])) + ϵ) * η
+
   return dx, (moments = (mt, vt), decays = βt .* β)
+end
+
+"""
+    RADAM(;η = 0.001, β = (0.9, 0.999), ϵ = mach_eps)
+
+[Rectified ADAM](https://arxiv.org/abs/1908.03265) optimizer.
+
+# Parameters
+- Learning rate (`η`): Amount by which gradients are discounted before updating
+                       the weights.
+- Decay of momentums (`β::Tuple`): Exponential decay for the first (β1) and the
+                                   second (β2) momentum estimate.
+- Machine epsilon (`ϵ::Float32`): Constant to prevent division by zero
+                                  (no need to change default)
+"""
+mutable struct RADAM{T,S}
+  eta::T
+  beta::Tuple{S,S}
+  epsilon::Float32
+end
+RADAM(;η = 0.001, β = (0.9, 0.999), ϵ = mach_eps) = RADAM(η, β, ϵ)
+
+init(o::RADAM, x::AbstractArray) = (moments = (zero(x), zero(x)), decays = o.beta, t = 1)
+
+(o::RADAM)(m, dm, state) = update!(o, m, dm, state)
+
+function apply!(o::RADAM, x, dx, state)
+  η, β, ϵ = o.eta, o.beta, o.epsilon
+  ρ∞ = 2/(1-β[2])-1
+
+  mt, vt = state.moments
+  βt, t = state.decays, state.t
+
+  @. mt = β[1] * mt + (1 - β[1]) * dx
+  @. vt = β[2] * vt + (1 - β[2]) * dx^2
+  ρ = ρ∞ - 2*t * βt[2] / (1 - βt[2])
+  if ρ > 4
+    r = sqrt((ρ - 4) * (ρ - 2) * ρ∞/((ρ∞ - 4) * (ρ∞ - 2) * ρ))
+    @. dx =  mt / (1 - βt[1]) / (sqrt(vt / (1 - βt[2])) + ϵ) * η * r
+  else
+    @. dx =  mt / (1 - βt[1]) * η
+  end
+
+  return dx, (moments = (mt, vt), decays = βt .* β, t = t + 1)
+end
+
+"""
+    AdaMax(;η = 0.001, β = (0.9, 0.999), ϵ = 1f-8)
+
+[AdaMax](https://arxiv.org/abs/1412.6980) is a variant of ADAM based on the ∞-norm.
+
+# Parameters
+- Learning rate (`η`): Amount by which gradients are discounted before updating
+                       the weights.
+- Decay of momentums (`β::Tuple`): Exponential decay for the first (β1) and the
+                                   second (β2) momentum estimate.
+- Machine epsilon (`ϵ::Float32`): Constant to prevent division by zero
+                                  (no need to change default)
+"""
+mutable struct AdaMax{T,S}
+  eta::T
+  beta::Tuple{S,S}
+  epsilon::Float32
+end
+AdaMax(;η = 0.001, β = (0.9, 0.999), ϵ = 1f-8) = AdaMax(η, β, ϵ)
+
+init(o::AdaMax, x::AbstractArray) = (moments = (zero(x), zero(x)), decays = o.beta)
+
+(o::AdaMax)(m, dm, state) = update!(o, m, dm, state)
+
+function apply!(o::AdaMax, x, dx, state)
+  η, β, ϵ = o.eta, o.beta, o.epsilon
+
+  mt, ut = state.moments
+  βt = state.decays
+
+  @. mt = β[1] * mt + (1 - β[1]) * dx
+  @. ut = max(β[2] * ut, abs(dx))
+  @. dx = (η/(1 - βt[1])) * mt/(ut + ϵ)
+
+  return dx, (moments = (mt, ut), decays = βt .* β)
+end
+
+"""
+    OADAM(;η = 0.001, β = (0.5, 0.9), ϵ = 1f-8)
+
+[OADAM](https://arxiv.org/abs/1711.00141) (Optimistic ADAM)
+is a variant of ADAM adding an "optimistic" term suitable for adversarial training.
+
+# Parameters
+- Learning rate (`η`): Amount by which gradients are discounted before updating
+                       the weights.
+- Decay of momentums (`β::Tuple`): Exponential decay for the first (β1) and the
+                                   second (β2) momentum estimate.
+- Machine epsilon (`ϵ::Float32`): Constant to prevent division by zero
+                                  (no need to change default)
+"""
+mutable struct OADAM{T,S}
+  eta::T
+  beta::Tuple{S,S}
+  epsilon::Float32
+end
+OADAM(;η = 0.001, β = (0.5, 0.9), ϵ = mach_eps) = OADAM(η, β, ϵ)
+
+init(o::OADAM, x::AbstractArray) = (moments = (zero(x), zero(x)), decays = o.beta, dx = zero(x))
+
+(o::OADAM)(m, dm, state) = update!(o, m, dm, state)
+
+function apply!(o::OADAM, x, dx, state)
+  η, β, ϵ = o.eta, o.beta, o.epsilon
+
+  mt, vt = state.moments
+  βt, dx_ = state.decays, state.dx
+
+  @. mt = β[1] * mt + (1 - β[1]) * dx
+  @. vt = β[2] * vt + (1 - β[2]) * dx^2
+  @. dx = -dx_
+  @. dx_ = η * mt / (1 - βt[1]) / (sqrt(vt / (1 - βt[2])) + ϵ)
+  @. dx += 2*dx_
+
+  return dx, (moments = (mt, vt), decays = βt .* β, dx = dx_)
+end
+
+"""
+    ADAGrad(;η = 0.1, ϵ = 1f-8)
+
+[ADAGrad](http://www.jmlr.org/papers/volume12/duchi11a/duchi11a.pdf) optimizer. It has
+parameter specific learning rates based on how frequently it is updated.
+Parameters don't need tuning.
+
+# Parameters
+- Learning rate (`η`): Amount by which gradients are discounted before updating
+                       the weights.
+- Machine epsilon (`ϵ::Float32`): Constant to prevent division by zero
+                                  (no need to change default)
+"""
+mutable struct ADAGrad{T}
+  eta::T
+  epsilon::Float32
+end
+ADAGrad(;η = 0.1, ϵ = mach_eps) = ADAGrad(η, ϵ)
+
+init(o::ADAGrad, x::AbstractArray) = (acceleration = fill!(similar(x), o.epsilon),)
+
+(o::ADAGrad)(m, dm, state) = update!(o, m, dm, state)
+
+function apply!(o::ADAGrad, x, dx, state)
+  η, ϵ = o.eta, o.epsilon
+  acc = state.acceleration
+
+  @. acc += dx^2
+  @. dx *= η / (sqrt(acc) + ϵ)
+
+  return dx, (acceleration = acc,)
+end
+
+"""
+    ADADelta(;ρ = 0.9, ϵ = 1f-8)
+
+[ADADelta](https://arxiv.org/abs/1212.5701) is a version of ADAGrad adapting its learning
+rate based on a window of past gradient updates.
+Parameters don't need tuning.
+
+# Parameters
+- Rho (`ρ`): Factor by which the gradient is decayed at each time step.
+- Machine epsilon (`ϵ::Float32`): Constant to prevent division by zero
+                                  (no need to change default)
+"""
+mutable struct ADADelta{T}
+  rho::T
+  epsilon::Float32
+end
+ADADelta(;ρ = 0.9, ϵ = mach_eps) = ADADelta(ρ, ϵ)
+
+init(o::ADADelta, x::AbstractArray) = (acceleration = zero(x), Δacceleration = zero(x))
+
+(o::ADADelta)(m, dm, state) = update!(o, m, dm, state)
+
+function apply!(o::ADADelta, x, dx, state)
+  ρ, ϵ = o.rho, o.epsilon
+  acc, Δacc = state.acceleration, state.Δacceleration
+
+  @. acc = ρ * acc + (1 - ρ) * dx^2
+  # DON'T remove epsilon from numerator
+  # or even out of the square roots
+  @. dx *= sqrt(Δacc + ϵ) / sqrt(acc + ϵ)
+  @. Δacc = ρ * Δacc + (1 - ρ) * dx^2
+  
+  return dx, (acceleration = acc, Δacceleration = Δacc)
+end
+
+"""
+    AMSGrad(;η = 0.001, β = (0.9, 0.999), ϵ = 1f-8)
+
+The [AMSGrad](https://openreview.net/forum?id=ryQu7f-RZ) version of the ADAM
+optimiser. Parameters don't need tuning.
+
+# Parameters
+- Learning rate (`η`): Amount by which gradients are discounted before updating
+                       the weights.
+- Decay of momentums (`β::Tuple`): Exponential decay for the first (β1) and the
+                                   second (β2) momentum estimate.
+- Machine epsilon (`ϵ::Float32`): Constant to prevent division by zero
+                                  (no need to change default)
+"""
+mutable struct AMSGrad{T,S}
+  eta::T
+  beta::Tuple{S,S}
+  epsilon::Float32
+end
+AMSGrad(;η = 0.001, β = (0.9, 0.999), ϵ = mach_eps) = AMSGrad(η, β, ϵ)
+
+init(o::AMSGrad, x::AbstractArray) =
+  (moments = (fill!(similar(x), o.epsilon), fill!(similar(x), o.epsilon), fill!(similar(x), o.epsilon)),)
+
+(o::AMSGrad)(m, dm, state) = update!(o, m, dm, state)
+
+function apply!(o::AMSGrad, x, dx, state)
+  η, β, ϵ = o.eta, o.beta, o.epsilon
+
+  mt, vt, v̂t = state.moments
+
+  @. mt = β[1] * mt + (1 - β[1]) * dx
+  @. vt = β[2] * vt + (1 - β[2]) * dx ^ 2
+  @. v̂t = max(v̂t, vt)
+  @. dx = η * mt / (sqrt(v̂t) + ϵ)
+
+  return dx, (moments = (mt, vt, v̂t),)
+end
+
+"""
+    NADAM(;η = 0.001, β = (0.9, 0.999), ϵ = 1f-8)
+
+[NADAM](https://openreview.net/forum?id=OM0jvwB8jIp57ZJjtNEZ) is a Nesterov variant of ADAM.
+Parameters don't need tuning.
+
+# Parameters
+- Learning rate (`η`): Amount by which gradients are discounted before updating
+                       the weights.
+- Decay of momentums (`β::Tuple`): Exponential decay for the first (β1) and the
+                                   second (β2) momentum estimate.
+- Machine epsilon (`ϵ::Float32`): Constant to prevent division by zero
+                                  (no need to change default)
+"""
+mutable struct NADAM{T,S}
+  eta::T
+  beta::Tuple{S,S}
+  epsilon::Float32
+end
+NADAM(;η = 0.001, β = (0.9, 0.999), ϵ = mach_eps) = NADAM(η, β, ϵ)
+
+init(o::NADAM, x::AbstractArray) = (moments = (zero(x), zero(x)), decays = o.beta)
+
+(o::NADAM)(m, dm, state) = update!(o, m, dm, state)
+
+function apply!(o::NADAM, x, dx, state)
+  η, β, ϵ = o.eta, o.beta, o.epsilon
+
+  mt, vt = state.moments
+  βt = state.decays
+
+  @. mt = β[1] * mt + (1 - β[1]) * dx
+  @. vt = β[2] * vt + (1 - β[2]) * dx^2
+  @. dx = (β[1] * mt / (1 - β[1] * βt[1]) + (1 - β[1]) * dx / (1 - βt[1])) / 
+          (sqrt(vt * β[2] / (1 - βt[2])) + ϵ) * η
+
+  return dx, (moments = (mt, vt), decays = βt .* β)
+end
+
+"""
+    ADAMW(;η = 0.001, β = (0.9, 0.999), γ = 0, ϵ = 1f-8)
+
+[ADAMW](https://arxiv.org/abs/1711.05101) is a variant of ADAM fixing (as in repairing) its
+weight decay regularization.
+
+# Parameters
+- Learning rate (`η`): Amount by which gradients are discounted before updating
+                       the weights.
+- Decay of momentums (`β::Tuple`): Exponential decay for the first (β1) and the
+                                   second (β2) momentum estimate.
+- `γ`: Decay applied to weights during optimisation.
+- Machine epsilon (`ϵ::Float32`): Constant to prevent division by zero
+                                  (no need to change default)
+"""
+ADAMW(;η = 0.001, β = (0.9, 0.999), γ = 0, ϵ = mach_eps) =
+  Sequence(ADAM(η, β, ϵ), WeightDecay(γ))
+
+"""
+    AdaBelief(;η = 0.001, β = (0.9, 0.999), ϵ = 1f-8)
+
+The [AdaBelief](https://arxiv.org/abs/2010.07468) optimiser is a variant of the well-known
+ADAM optimiser.
+
+# Parameters
+- Learning rate (`η`): Amount by which gradients are discounted before updating
+                       the weights.
+- Decay of momentums (`β::Tuple`): Exponential decay for the first (β1) and the
+                                   second (β2) momentum estimate.
+- Machine epsilon (`ϵ::Float32`): Constant to prevent division by zero
+                                  (no need to change default)
+"""
+mutable struct AdaBelief{T,S}
+  eta::T
+  beta::Tuple{S,S}
+  epsilon::Float32
+end
+AdaBelief(;η = 0.001, β = (0.9, 0.999), ϵ = mach_eps) = AdaBelief(η, β, ϵ)
+
+init(o::AdaBelief, x::AbstractArray) = (moments = (zero(x), zero(x)),)
+
+(o::AdaBelief)(m, dm, state) = update!(o, m, dm, state)
+
+function apply!(o::AdaBelief, x, dx, state)
+  η, β, ϵ = o.eta, o.beta, o.epsilon
+  mt, st = state.moments
+
+  @. mt = β[1] * mt + (1 - β[1]) * dx
+  @. st = β[2] * st + (1 - β[2]) * (dx - mt)^2
+  @. dx =  η * mt / (sqrt(st) + ϵ)
+  
+  return dx, (moments = (mt, st),)
+end
+
+"""
+    WeightDecay(;γ = 0)
+
+Decay weights by `wd`.
+
+# Parameters
+- Weight decay (`γ`)
+"""
+mutable struct WeightDecay{T}
+  wd::T
+end
+WeightDecay(;γ = 1e-4) = WeightDecay(γ)
+
+init(o::WeightDecay, x::AbstractArray) = nothing
+
+(o::WeightDecay)(m, dm, state) = update!(o, m, dm, state)
+
+function apply!(o::WeightDecay, x, dx, state)
+  @. dx += o.wd * x
+
+  return dx, state
+end
+
+"""
+    Sequence(opts...)
+
+Compose a sequence of optimisers so that each `opt` in `opts`
+updates the gradient in the order specified.
+"""
+struct Sequence{O}
+  opts::O
+end
+Sequence(opts...) = Sequence(opts)
+
+init(o::Sequence, x::AbstractArray) = [init(opt, x) for opt in o.opts]
+
+(o::Sequence)(m, dm, state) = update!(o, m, dm, state)
+
+function apply!(o::Sequence, x, dx, states)
+  for (i, (opt, state)) in enumerate(zip(o.opts, states))
+    dx, states[i] = apply!(opt, x, dx, state)
+  end
+
+  return dx, states
 end

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -1,7 +1,7 @@
 const mach_eps = 1f-8
 
 """
-    Descent(;η = 0.1)
+    Descent(; η = 0.1)
 
 Classic gradient descent optimiser with learning rate `η`.
 For each parameter `p` and its gradient `dp`, this runs `p -= η*dp`.
@@ -13,21 +13,21 @@ For each parameter `p` and its gradient `dp`, this runs `p -= η*dp`.
 mutable struct Descent{T}
   eta::T
 end
-Descent(;η = 0.1) = Descent(η)
+Descent(; η = 0.1) = Descent(η)
 
 init(o::Descent, x::AbstractArray) = nothing
 
-function apply!(o::Descent, x, dx, state)
+function apply(o::Descent, x, dx, state)
   η = convert(eltype(dx), o.eta)
   dx .*= η
   
-  return dx, state
+  return dx .* η, state
 end
 
-(o::Descent)(m, dm, st) = update!(o, m, dm, st)
+(o::Descent)(m, dm, st) = update(o, m, dm, st)
 
 """
-    Momentum(;η = 0.01, ρ = 0.9)
+    Momentum(; η = 0.01, ρ = 0.9)
 
 Gradient descent optimizer with learning rate `η` and momentum `ρ`.
 
@@ -41,22 +41,21 @@ mutable struct Momentum{T,S}
   eta::T
   rho::S
 end
-Momentum(;η = 0.01, ρ = 0.9) = Momentum(η, ρ)
+Momentum(; η = 0.01, ρ = 0.9) = Momentum(η, ρ)
 
 init(o::Momentum, x::AbstractArray) = (velocity = zero(x),)
 
-function apply!(o::Momentum, x, dx, state)
+function apply(o::Momentum, x, dx, state)
   η, ρ, v = o.eta, o.rho, state.velocity
   @. v = ρ * v - η * dx
-  @. dx = -v
   
-  return dx, (velocity = v,)
+  return -v, (velocity = v,)
 end
 
-(o::Momentum)(m, dm, state) = update!(o, m, dm, state)
+(o::Momentum)(m, dm, state) = update(o, m, dm, state)
 
 """
-    Nesterov(;η = 0.001, ρ = 0.9)
+    Nesterov(; η = 0.001, ρ = 0.9)
 
 Gradient descent optimizer with learning rate `η` and Nesterov momentum `ρ`.
 
@@ -70,23 +69,22 @@ mutable struct Nesterov{T,S}
   eta::T
   rho::S
 end
-Nesterov(;η = 0.001, ρ = 0.9) = Nesterov(η, ρ)
+Nesterov(; η = 0.001, ρ = 0.9) = Nesterov(η, ρ)
 
 init(o::Nesterov, x::AbstractArray) = (velocity = zero(x),)
 
-(o::Nesterov)(m, dm, state) = update!(o, m, dm, state)
+(o::Nesterov)(m, dm, state) = update(o, m, dm, state)
 
-function apply!(o::Nesterov, x, dx, state)
+function apply(o::Nesterov, x, dx, state)
   η, ρ, v = o.eta, o.rho, state.velocity
   d = @. ρ^2 * v - (1+ρ) * η * dx
   @. v = ρ * v - η * dx
-  @. dx = -d
   
-  return dx, (velocity = v,)
+  return -d, (velocity = v,)
 end
 
 """
-    RMSProp(;η = 0.001, ρ = 0.9, ϵ = 1f-8)
+    RMSProp(; η = 0.001, ρ = 0.9, ϵ = 1f-8)
 
 Optimizer using the
 [RMSProp](https://www.cs.toronto.edu/~tijmen/csc321/slides/lecture_slides_lec6.pdf)
@@ -106,22 +104,22 @@ mutable struct RMSProp{T,S}
   rho::S
   epsilon::Float32
 end
-RMSProp(;η = 0.001, ρ = 0.9, ϵ = mach_eps) = RMSProp(η, ρ, ϵ)
+RMSProp(; η = 0.001, ρ = 0.9, ϵ = mach_eps) = RMSProp(η, ρ, ϵ)
 
 init(o::RMSProp, x::AbstractArray) = (acceleration = zero(x),)
 
-function apply!(o::RMSProp, x, dx, state)
+function apply(o::RMSProp, x, dx, state)
   η, ρ, ϵ, acc = o.eta, o.rho, o.epsilon, state.acceleration
   @. acc = ρ * acc + (1 - ρ) * dx^2
-  @. dx = dx * (η / (sqrt(acc) + ϵ))
+  dx = @. dx * (η / (sqrt(acc) + ϵ))
   
   return dx, (acceleration = acc,)
 end
 
-(o::RMSProp)(m, dm, state) = update!(o, m, dm, state)
+(o::RMSProp)(m, dm, state) = update(o, m, dm, state)
 
 """
-    ADAM(;η = 0.001, β = (0.9, 0.999), ϵ = 1f-8)
+    ADAM(; η = 0.001, β = (0.9, 0.999), ϵ = 1f-8)
 
 [ADAM](https://arxiv.org/abs/1412.6980) optimiser.
 
@@ -138,25 +136,25 @@ mutable struct ADAM{T,K}
   beta::Tuple{K,K}
   epsilon::Float32
 end
-ADAM(;η = 0.001, β = (0.9, 0.999), ϵ = mach_eps) = ADAM(η, β, ϵ)
+ADAM(; η = 0.001, β = (0.9, 0.999), ϵ = mach_eps) = ADAM(η, β, ϵ)
 
 init(o::ADAM, x::AbstractArray) = (moments = (zero(x), zero(x)), decays = o.beta)
 
-(o::ADAM)(m, dm, state) = update!(o, m, dm, state)
+(o::ADAM)(m, dm, state) = update(o, m, dm, state)
 
-function apply!(o::ADAM{T}, x, dx, state) where T
+function apply(o::ADAM{T}, x, dx, state) where T
   η, β, βt, ϵ = o.eta, o.beta, state.decays, o.epsilon
   mt, vt = state.moments
 
   @. mt = β[1] * mt + (one(T) - β[1]) * dx
   @. vt = β[2] * vt + (one(T) - β[2]) * dx ^ 2
-  @. dx =  mt / (one(T) - βt[1]) / (sqrt(vt / (one(T) - βt[2])) + ϵ) * η
+  dx = @. mt / (one(T) - βt[1]) / (sqrt(vt / (one(T) - βt[2])) + ϵ) * η
 
   return dx, (moments = (mt, vt), decays = βt .* β)
 end
 
 """
-    RADAM(;η = 0.001, β = (0.9, 0.999), ϵ = mach_eps)
+    RADAM(; η = 0.001, β = (0.9, 0.999), ϵ = mach_eps)
 
 [Rectified ADAM](https://arxiv.org/abs/1908.03265) optimizer.
 
@@ -173,13 +171,13 @@ mutable struct RADAM{T,S}
   beta::Tuple{S,S}
   epsilon::Float32
 end
-RADAM(;η = 0.001, β = (0.9, 0.999), ϵ = mach_eps) = RADAM(η, β, ϵ)
+RADAM(; η = 0.001, β = (0.9, 0.999), ϵ = mach_eps) = RADAM(η, β, ϵ)
 
 init(o::RADAM, x::AbstractArray) = (moments = (zero(x), zero(x)), decays = o.beta, t = 1)
 
-(o::RADAM)(m, dm, state) = update!(o, m, dm, state)
+(o::RADAM)(m, dm, state) = update(o, m, dm, state)
 
-function apply!(o::RADAM, x, dx, state)
+function apply(o::RADAM, x, dx, state)
   η, β, ϵ = o.eta, o.beta, o.epsilon
   ρ∞ = 2/(1-β[2])-1
 
@@ -191,16 +189,16 @@ function apply!(o::RADAM, x, dx, state)
   ρ = ρ∞ - 2*t * βt[2] / (1 - βt[2])
   if ρ > 4
     r = sqrt((ρ - 4) * (ρ - 2) * ρ∞/((ρ∞ - 4) * (ρ∞ - 2) * ρ))
-    @. dx =  mt / (1 - βt[1]) / (sqrt(vt / (1 - βt[2])) + ϵ) * η * r
+    dx = @. mt / (1 - βt[1]) / (sqrt(vt / (1 - βt[2])) + ϵ) * η * r
   else
-    @. dx =  mt / (1 - βt[1]) * η
+    dx = @. mt / (1 - βt[1]) * η
   end
 
   return dx, (moments = (mt, vt), decays = βt .* β, t = t + 1)
 end
 
 """
-    AdaMax(;η = 0.001, β = (0.9, 0.999), ϵ = 1f-8)
+    AdaMax(; η = 0.001, β = (0.9, 0.999), ϵ = 1f-8)
 
 [AdaMax](https://arxiv.org/abs/1412.6980) is a variant of ADAM based on the ∞-norm.
 
@@ -217,13 +215,13 @@ mutable struct AdaMax{T,S}
   beta::Tuple{S,S}
   epsilon::Float32
 end
-AdaMax(;η = 0.001, β = (0.9, 0.999), ϵ = 1f-8) = AdaMax(η, β, ϵ)
+AdaMax(; η = 0.001, β = (0.9, 0.999), ϵ = 1f-8) = AdaMax(η, β, ϵ)
 
 init(o::AdaMax, x::AbstractArray) = (moments = (zero(x), zero(x)), decays = o.beta)
 
-(o::AdaMax)(m, dm, state) = update!(o, m, dm, state)
+(o::AdaMax)(m, dm, state) = update(o, m, dm, state)
 
-function apply!(o::AdaMax, x, dx, state)
+function apply(o::AdaMax, x, dx, state)
   η, β, ϵ = o.eta, o.beta, o.epsilon
 
   mt, ut = state.moments
@@ -231,13 +229,13 @@ function apply!(o::AdaMax, x, dx, state)
 
   @. mt = β[1] * mt + (1 - β[1]) * dx
   @. ut = max(β[2] * ut, abs(dx))
-  @. dx = (η/(1 - βt[1])) * mt/(ut + ϵ)
+  dx = @. (η/(1 - βt[1])) * mt/(ut + ϵ)
 
   return dx, (moments = (mt, ut), decays = βt .* β)
 end
 
 """
-    OADAM(;η = 0.001, β = (0.5, 0.9), ϵ = 1f-8)
+    OADAM(; η = 0.001, β = (0.5, 0.9), ϵ = 1f-8)
 
 [OADAM](https://arxiv.org/abs/1711.00141) (Optimistic ADAM)
 is a variant of ADAM adding an "optimistic" term suitable for adversarial training.
@@ -255,13 +253,13 @@ mutable struct OADAM{T,S}
   beta::Tuple{S,S}
   epsilon::Float32
 end
-OADAM(;η = 0.001, β = (0.5, 0.9), ϵ = mach_eps) = OADAM(η, β, ϵ)
+OADAM(; η = 0.001, β = (0.5, 0.9), ϵ = mach_eps) = OADAM(η, β, ϵ)
 
 init(o::OADAM, x::AbstractArray) = (moments = (zero(x), zero(x)), decays = o.beta, dx = zero(x))
 
-(o::OADAM)(m, dm, state) = update!(o, m, dm, state)
+(o::OADAM)(m, dm, state) = update(o, m, dm, state)
 
-function apply!(o::OADAM, x, dx, state)
+function apply(o::OADAM, x, dx, state)
   η, β, ϵ = o.eta, o.beta, o.epsilon
 
   mt, vt = state.moments
@@ -271,13 +269,13 @@ function apply!(o::OADAM, x, dx, state)
   @. vt = β[2] * vt + (1 - β[2]) * dx^2
   @. dx = -dx_
   @. dx_ = η * mt / (1 - βt[1]) / (sqrt(vt / (1 - βt[2])) + ϵ)
-  @. dx += 2*dx_
+  dx = @. dx + 2*dx_
 
   return dx, (moments = (mt, vt), decays = βt .* β, dx = dx_)
 end
 
 """
-    ADAGrad(;η = 0.1, ϵ = 1f-8)
+    ADAGrad(; η = 0.1, ϵ = 1f-8)
 
 [ADAGrad](http://www.jmlr.org/papers/volume12/duchi11a/duchi11a.pdf) optimizer. It has
 parameter specific learning rates based on how frequently it is updated.
@@ -293,24 +291,24 @@ mutable struct ADAGrad{T}
   eta::T
   epsilon::Float32
 end
-ADAGrad(;η = 0.1, ϵ = mach_eps) = ADAGrad(η, ϵ)
+ADAGrad(; η = 0.1, ϵ = mach_eps) = ADAGrad(η, ϵ)
 
 init(o::ADAGrad, x::AbstractArray) = (acceleration = fill!(similar(x), o.epsilon),)
 
-(o::ADAGrad)(m, dm, state) = update!(o, m, dm, state)
+(o::ADAGrad)(m, dm, state) = update(o, m, dm, state)
 
-function apply!(o::ADAGrad, x, dx, state)
+function apply(o::ADAGrad, x, dx, state)
   η, ϵ = o.eta, o.epsilon
   acc = state.acceleration
 
   @. acc += dx^2
-  @. dx *= η / (sqrt(acc) + ϵ)
+  dx = @. dx * η / (sqrt(acc) + ϵ)
 
   return dx, (acceleration = acc,)
 end
 
 """
-    ADADelta(;ρ = 0.9, ϵ = 1f-8)
+    ADADelta(; ρ = 0.9, ϵ = 1f-8)
 
 [ADADelta](https://arxiv.org/abs/1212.5701) is a version of ADAGrad adapting its learning
 rate based on a window of past gradient updates.
@@ -325,27 +323,27 @@ mutable struct ADADelta{T}
   rho::T
   epsilon::Float32
 end
-ADADelta(;ρ = 0.9, ϵ = mach_eps) = ADADelta(ρ, ϵ)
+ADADelta(; ρ = 0.9, ϵ = mach_eps) = ADADelta(ρ, ϵ)
 
 init(o::ADADelta, x::AbstractArray) = (acceleration = zero(x), Δacceleration = zero(x))
 
-(o::ADADelta)(m, dm, state) = update!(o, m, dm, state)
+(o::ADADelta)(m, dm, state) = update(o, m, dm, state)
 
-function apply!(o::ADADelta, x, dx, state)
+function apply(o::ADADelta, x, dx, state)
   ρ, ϵ = o.rho, o.epsilon
   acc, Δacc = state.acceleration, state.Δacceleration
 
   @. acc = ρ * acc + (1 - ρ) * dx^2
   # DON'T remove epsilon from numerator
   # or even out of the square roots
-  @. dx *= sqrt(Δacc + ϵ) / sqrt(acc + ϵ)
+  dx = @. dx * sqrt(Δacc + ϵ) / sqrt(acc + ϵ)
   @. Δacc = ρ * Δacc + (1 - ρ) * dx^2
   
   return dx, (acceleration = acc, Δacceleration = Δacc)
 end
 
 """
-    AMSGrad(;η = 0.001, β = (0.9, 0.999), ϵ = 1f-8)
+    AMSGrad(; η = 0.001, β = (0.9, 0.999), ϵ = 1f-8)
 
 The [AMSGrad](https://openreview.net/forum?id=ryQu7f-RZ) version of the ADAM
 optimiser. Parameters don't need tuning.
@@ -363,14 +361,14 @@ mutable struct AMSGrad{T,S}
   beta::Tuple{S,S}
   epsilon::Float32
 end
-AMSGrad(;η = 0.001, β = (0.9, 0.999), ϵ = mach_eps) = AMSGrad(η, β, ϵ)
+AMSGrad(; η = 0.001, β = (0.9, 0.999), ϵ = mach_eps) = AMSGrad(η, β, ϵ)
 
 init(o::AMSGrad, x::AbstractArray) =
   (moments = (fill!(similar(x), o.epsilon), fill!(similar(x), o.epsilon), fill!(similar(x), o.epsilon)),)
 
-(o::AMSGrad)(m, dm, state) = update!(o, m, dm, state)
+(o::AMSGrad)(m, dm, state) = update(o, m, dm, state)
 
-function apply!(o::AMSGrad, x, dx, state)
+function apply(o::AMSGrad, x, dx, state)
   η, β, ϵ = o.eta, o.beta, o.epsilon
 
   mt, vt, v̂t = state.moments
@@ -378,13 +376,13 @@ function apply!(o::AMSGrad, x, dx, state)
   @. mt = β[1] * mt + (1 - β[1]) * dx
   @. vt = β[2] * vt + (1 - β[2]) * dx ^ 2
   @. v̂t = max(v̂t, vt)
-  @. dx = η * mt / (sqrt(v̂t) + ϵ)
+  dx = @. η * mt / (sqrt(v̂t) + ϵ)
 
   return dx, (moments = (mt, vt, v̂t),)
 end
 
 """
-    NADAM(;η = 0.001, β = (0.9, 0.999), ϵ = 1f-8)
+    NADAM(; η = 0.001, β = (0.9, 0.999), ϵ = 1f-8)
 
 [NADAM](https://openreview.net/forum?id=OM0jvwB8jIp57ZJjtNEZ) is a Nesterov variant of ADAM.
 Parameters don't need tuning.
@@ -402,13 +400,13 @@ mutable struct NADAM{T,S}
   beta::Tuple{S,S}
   epsilon::Float32
 end
-NADAM(;η = 0.001, β = (0.9, 0.999), ϵ = mach_eps) = NADAM(η, β, ϵ)
+NADAM(; η = 0.001, β = (0.9, 0.999), ϵ = mach_eps) = NADAM(η, β, ϵ)
 
 init(o::NADAM, x::AbstractArray) = (moments = (zero(x), zero(x)), decays = o.beta)
 
-(o::NADAM)(m, dm, state) = update!(o, m, dm, state)
+(o::NADAM)(m, dm, state) = update(o, m, dm, state)
 
-function apply!(o::NADAM, x, dx, state)
+function apply(o::NADAM, x, dx, state)
   η, β, ϵ = o.eta, o.beta, o.epsilon
 
   mt, vt = state.moments
@@ -416,14 +414,14 @@ function apply!(o::NADAM, x, dx, state)
 
   @. mt = β[1] * mt + (1 - β[1]) * dx
   @. vt = β[2] * vt + (1 - β[2]) * dx^2
-  @. dx = (β[1] * mt / (1 - β[1] * βt[1]) + (1 - β[1]) * dx / (1 - βt[1])) / 
+  dx = @. (β[1] * mt / (1 - β[1] * βt[1]) + (1 - β[1]) * dx / (1 - βt[1])) / 
           (sqrt(vt * β[2] / (1 - βt[2])) + ϵ) * η
 
   return dx, (moments = (mt, vt), decays = βt .* β)
 end
 
 """
-    ADAMW(;η = 0.001, β = (0.9, 0.999), γ = 0, ϵ = 1f-8)
+    ADAMW(; η = 0.001, β = (0.9, 0.999), γ = 0, ϵ = 1f-8)
 
 [ADAMW](https://arxiv.org/abs/1711.05101) is a variant of ADAM fixing (as in repairing) its
 weight decay regularization.
@@ -437,8 +435,8 @@ weight decay regularization.
 - Machine epsilon (`ϵ::Float32`): Constant to prevent division by zero
                                   (no need to change default)
 """
-ADAMW(;η = 0.001, β = (0.9, 0.999), γ = 0, ϵ = mach_eps) =
-  Sequence(ADAM(η, β, ϵ), WeightDecay(γ))
+ADAMW(; η = 0.001, β = (0.9, 0.999), γ = 0, ϵ = mach_eps) =
+  SequenceOptimiser(ADAM(η, β, ϵ), WeightDecay(γ))
 
 """
     AdaBelief(;η = 0.001, β = (0.9, 0.999), ϵ = 1f-8)
@@ -459,25 +457,25 @@ mutable struct AdaBelief{T,S}
   beta::Tuple{S,S}
   epsilon::Float32
 end
-AdaBelief(;η = 0.001, β = (0.9, 0.999), ϵ = mach_eps) = AdaBelief(η, β, ϵ)
+AdaBelief(; η = 0.001, β = (0.9, 0.999), ϵ = mach_eps) = AdaBelief(η, β, ϵ)
 
 init(o::AdaBelief, x::AbstractArray) = (moments = (zero(x), zero(x)),)
 
-(o::AdaBelief)(m, dm, state) = update!(o, m, dm, state)
+(o::AdaBelief)(m, dm, state) = update(o, m, dm, state)
 
-function apply!(o::AdaBelief, x, dx, state)
+function apply(o::AdaBelief, x, dx, state)
   η, β, ϵ = o.eta, o.beta, o.epsilon
   mt, st = state.moments
 
   @. mt = β[1] * mt + (1 - β[1]) * dx
   @. st = β[2] * st + (1 - β[2]) * (dx - mt)^2
-  @. dx =  η * mt / (sqrt(st) + ϵ)
+  dx = @. η * mt / (sqrt(st) + ϵ)
   
   return dx, (moments = (mt, st),)
 end
 
 """
-    WeightDecay(;γ = 0)
+    WeightDecay(; γ = 0)
 
 Decay weights by `wd`.
 
@@ -487,36 +485,36 @@ Decay weights by `wd`.
 mutable struct WeightDecay{T}
   wd::T
 end
-WeightDecay(;γ = 1e-4) = WeightDecay(γ)
+WeightDecay(; γ = 1e-4) = WeightDecay(γ)
 
 init(o::WeightDecay, x::AbstractArray) = nothing
 
-(o::WeightDecay)(m, dm, state) = update!(o, m, dm, state)
+(o::WeightDecay)(m, dm, state) = update(o, m, dm, state)
 
-function apply!(o::WeightDecay, x, dx, state)
-  @. dx += o.wd * x
+function apply(o::WeightDecay, x, dx, state)
+  dx = @. dx + o.wd * x
 
   return dx, state
 end
 
 """
-    Sequence(opts...)
+    SequenceOptimiser(opts...)
 
 Compose a sequence of optimisers so that each `opt` in `opts`
 updates the gradient in the order specified.
 """
-struct Sequence{O}
+struct SequenceOptimiser{O}
   opts::O
 end
-Sequence(opts...) = Sequence(opts)
+SequenceOptimiser(opts...) = SequenceOptimiser(opts)
 
-init(o::Sequence, x::AbstractArray) = [init(opt, x) for opt in o.opts]
+init(o::SequenceOptimiser, x::AbstractArray) = [init(opt, x) for opt in o.opts]
 
-(o::Sequence)(m, dm, state) = update!(o, m, dm, state)
+(o::SequenceOptimiser)(m, dm, state) = update(o, m, dm, state)
 
-function apply!(o::Sequence, x, dx, states)
+function apply(o::SequenceOptimiser, x, dx, states)
   for (i, (opt, state)) in enumerate(zip(o.opts, states))
-    dx, states[i] = apply!(opt, x, dx, state)
+    dx, states[i] = apply(opt, x, dx, state)
   end
 
   return dx, states

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -492,21 +492,21 @@ function apply(o::WeightDecay, x, dx, state)
 end
 
 """
-    SequenceOptimiser(opts...)
+    ChainOptimiser(opts...)
 
-Compose a sequence of optimisers so that each `opt` in `opts`
+Compose a chain (sequence) of optimisers so that each `opt` in `opts`
 updates the gradient in the order specified.
 """
-struct SequenceOptimiser{O}
+struct ChainOptimiser{O}
   opts::O
 end
-SequenceOptimiser(opts...) = SequenceOptimiser(opts)
+ChainOptimiser(opts...) = ChainOptimiser(opts)
 
-init(o::SequenceOptimiser, x::AbstractArray) = [init(opt, x) for opt in o.opts]
+init(o::ChainOptimiser, x::AbstractArray) = [init(opt, x) for opt in o.opts]
 
-(o::SequenceOptimiser)(m, dm, state) = update(o, m, dm, state)
+(o::ChainOptimiser)(m, dm, state) = update(o, m, dm, state)
 
-function apply(o::SequenceOptimiser, x, dx, states)
+function apply(o::ChainOptimiser, x, dx, states)
   new_states = similar(states)
   for (i, (opt, state)) in enumerate(zip(o.opts, states))
     dx, new_states[i] = apply(opt, x, dx, state)

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -1,5 +1,5 @@
 """
-    Descent(η = 0.1)
+    Descent(η = 1f-1)
 
 Classic gradient descent optimiser with learning rate `η`.
 For each parameter `p` and its gradient `dp`, this runs `p -= η*dp`.
@@ -11,7 +11,7 @@ For each parameter `p` and its gradient `dp`, this runs `p -= η*dp`.
 struct Descent{T}
   eta::T
 end
-Descent() = Descent(0.1)
+Descent() = Descent(1f-1)
 
 init(o::Descent, x::AbstractArray) = nothing
 
@@ -25,7 +25,7 @@ end
 (o::Descent)(m, dm, st) = update(o, m, dm, st)
 
 """
-    Momentum(η = 0.01, ρ = 0.9)
+    Momentum(η = 1f-2, ρ = 9f-1)
 
 Gradient descent optimizer with learning rate `η` and momentum `ρ`.
 
@@ -39,7 +39,7 @@ struct Momentum{T}
   eta::T
   rho::T
 end
-Momentum(η = 0.01, ρ = 0.9) = Momentum(η, ρ)
+Momentum(η = 1f-2, ρ = 9f-1) = Momentum(η, ρ)
 
 init(o::Momentum, x::AbstractArray) = zero(x)
 
@@ -53,7 +53,7 @@ end
 (o::Momentum)(m, dm, state) = update(o, m, dm, state)
 
 """
-    Nesterov(η = 0.001, ρ = 0.9)
+    Nesterov(η = 1f-3, ρ = 9f-1)
 
 Gradient descent optimizer with learning rate `η` and Nesterov momentum `ρ`.
 
@@ -67,7 +67,7 @@ struct Nesterov{T}
   eta::T
   rho::T
 end
-Nesterov(η = 0.001, ρ = 0.9) = Nesterov(η, ρ)
+Nesterov(η = 1f-3, ρ = 9f-1) = Nesterov(η, ρ)
 
 init(o::Nesterov, x::AbstractArray) = zero(x)
 
@@ -82,7 +82,7 @@ function apply(o::Nesterov, x, dx, state)
 end
 
 """
-    RMSProp(η = 0.001, ρ = 0.9, ϵ = eps(typeof(η)))
+    RMSProp(η = 1f-3, ρ = 9f-1, ϵ = eps(typeof(η)))
 
 Optimizer using the
 [RMSProp](https://www.cs.toronto.edu/~tijmen/csc321/slides/lecture_slides_lec6.pdf)
@@ -102,7 +102,7 @@ struct RMSProp{T}
   rho::T
   epsilon::T
 end
-RMSProp(η = 0.001, ρ = 0.9, ϵ = eps(typeof(η))) = RMSProp(η, ρ, ϵ)
+RMSProp(η = 1f-3, ρ = 9f-1, ϵ = eps(typeof(η))) = RMSProp(η, ρ, ϵ)
 
 init(o::RMSProp, x::AbstractArray) = zero(x)
 
@@ -117,7 +117,7 @@ end
 (o::RMSProp)(m, dm, state) = update(o, m, dm, state)
 
 """
-    ADAM(η = 0.001, β = (0.9, 0.999), ϵ = eps(typeof(η)))
+    ADAM(η = 1f-3, β = (9f-1, 9.99f-1), ϵ = eps(typeof(η)))
 
 [ADAM](https://arxiv.org/abs/1412.6980) optimiser.
 
@@ -134,7 +134,7 @@ struct ADAM{T}
   beta::Tuple{T, T}
   epsilon::T
 end
-ADAM(η = 0.001, β = (0.9, 0.999), ϵ = eps(typeof(η))) = ADAM(η, β, ϵ)
+ADAM(η = 1f-3, β = (9f-1, 9.99f-1), ϵ = eps(typeof(η))) = ADAM(η, β, ϵ)
 
 init(o::ADAM, x::AbstractArray) = (zero(x), zero(x), o.beta)
 
@@ -152,7 +152,7 @@ function apply(o::ADAM{T}, x, dx, state) where T
 end
 
 """
-    RADAM(η = 0.001, β = (0.9, 0.999), ϵ = eps(typeof(η)))
+    RADAM(η = 1f-3, β = (9f-1, 9.99f-1), ϵ = eps(typeof(η)))
 
 [Rectified ADAM](https://arxiv.org/abs/1908.03265) optimizer.
 
@@ -169,7 +169,7 @@ struct RADAM{T}
   beta::Tuple{T, T}
   epsilon::T
 end
-RADAM(η = 0.001, β = (0.9, 0.999), ϵ = eps(typeof(η))) = RADAM(η, β, ϵ)
+RADAM(η = 1f-3, β = (9f-1, 9.99f-1), ϵ = eps(typeof(η))) = RADAM(η, β, ϵ)
 
 init(o::RADAM, x::AbstractArray) = (zero(x), zero(x), o.beta, 1)
 
@@ -195,7 +195,7 @@ function apply(o::RADAM, x, dx, state)
 end
 
 """
-    AdaMax(η = 0.001, β = (0.9, 0.999), ϵ = eps(typeof(η)))
+    AdaMax(η = 1f-3, β = (9f-1, 9.99f-1), ϵ = eps(typeof(η)))
 
 [AdaMax](https://arxiv.org/abs/1412.6980) is a variant of ADAM based on the ∞-norm.
 
@@ -212,7 +212,7 @@ struct AdaMax{T}
   beta::Tuple{T, T}
   epsilon::T
 end
-AdaMax(η = 0.001, β = (0.9, 0.999), ϵ = eps(typeof(η))) = AdaMax(η, β, ϵ)
+AdaMax(η = 1f-3, β = (9f-1, 9.99f-1), ϵ = eps(typeof(η))) = AdaMax(η, β, ϵ)
 
 init(o::AdaMax, x::AbstractArray) = (zero(x), zero(x), o.beta)
 
@@ -231,7 +231,7 @@ function apply(o::AdaMax, x, dx, state)
 end
 
 """
-    OADAM(η = 0.001, β = (0.5, 0.9), ϵ = eps(typeof(η)))
+    OADAM(η = 1f-3, β = (5f-1, 9f-1), ϵ = eps(typeof(η)))
 
 [OADAM](https://arxiv.org/abs/1711.00141) (Optimistic ADAM)
 is a variant of ADAM adding an "optimistic" term suitable for adversarial training.
@@ -249,7 +249,7 @@ struct OADAM{T}
   beta::Tuple{T, T}
   epsilon::T
 end
-OADAM(η = 0.001, β = (0.5, 0.9), ϵ = eps(typeof(η))) = OADAM(η, β, ϵ)
+OADAM(η = 1f-3, β = (5f-1, 9f-1), ϵ = eps(typeof(η))) = OADAM(η, β, ϵ)
 
 init(o::OADAM, x::AbstractArray) = (zero(x), zero(x), o.beta, zero(x))
 
@@ -270,7 +270,7 @@ function apply(o::OADAM, x, dx, state)
 end
 
 """
-    ADAGrad(η = 0.1, ϵ = eps(typeof(η)))
+    ADAGrad(η = 1f-1, ϵ = eps(typeof(η)))
 
 [ADAGrad](http://www.jmlr.org/papers/volume12/duchi11a/duchi11a.pdf) optimizer. It has
 parameter specific learning rates based on how frequently it is updated.
@@ -286,7 +286,7 @@ struct ADAGrad{T}
   eta::T
   epsilon::T
 end
-ADAGrad(η = 0.1, ϵ = eps(typeof(η))) = ADAGrad(η, ϵ)
+ADAGrad(η = 1f-1, ϵ = eps(typeof(η))) = ADAGrad(η, ϵ)
 
 init(o::ADAGrad, x::AbstractArray) = fill!(similar(x), o.epsilon)
 
@@ -303,7 +303,7 @@ function apply(o::ADAGrad, x, dx, state)
 end
 
 """
-    ADADelta(ρ = 0.9, ϵ = eps(typeof(ρ)))
+    ADADelta(ρ = 9f-1, ϵ = eps(typeof(ρ)))
 
 [ADADelta](https://arxiv.org/abs/1212.5701) is a version of ADAGrad adapting its learning
 rate based on a window of past gradient updates.
@@ -318,7 +318,7 @@ struct ADADelta{T}
   rho::T
   epsilon::T
 end
-ADADelta(ρ = 0.9, ϵ = eps(typeof(ρ))) = ADADelta(ρ, ϵ)
+ADADelta(ρ = 9f-1, ϵ = eps(typeof(ρ))) = ADADelta(ρ, ϵ)
 
 init(o::ADADelta, x::AbstractArray) = (zero(x), zero(x))
 
@@ -338,7 +338,7 @@ function apply(o::ADADelta, x, dx, state)
 end
 
 """
-    AMSGrad(η = 0.001, β = (0.9, 0.999), ϵ = eps(typeof(η)))
+    AMSGrad(η = 1f-3, β = (9f-1, 9.99f-1), ϵ = eps(typeof(η)))
 
 The [AMSGrad](https://openreview.net/forum?id=ryQu7f-RZ) version of the ADAM
 optimiser. Parameters don't need tuning.
@@ -356,7 +356,7 @@ struct AMSGrad{T}
   beta::Tuple{T, T}
   epsilon::T
 end
-AMSGrad(η = 0.001, β = (0.9, 0.999), ϵ = eps(typeof(η))) = AMSGrad(η, β, ϵ)
+AMSGrad(η = 1f-3, β = (9f-1, 9.99f-1), ϵ = eps(typeof(η))) = AMSGrad(η, β, ϵ)
 
 init(o::AMSGrad, x::AbstractArray) =
   (fill!(similar(x), o.epsilon), fill!(similar(x), o.epsilon), fill!(similar(x), o.epsilon))
@@ -377,7 +377,7 @@ function apply(o::AMSGrad, x, dx, state)
 end
 
 """
-    NADAM(η = 0.001, β = (0.9, 0.999), ϵ = eps(typeof(η)))
+    NADAM(η = 1f-3, β = (9f-1, 9.99f-1), ϵ = eps(typeof(η)))
 
 [NADAM](https://openreview.net/forum?id=OM0jvwB8jIp57ZJjtNEZ) is a Nesterov variant of ADAM.
 Parameters don't need tuning.
@@ -395,7 +395,7 @@ struct NADAM{T}
   beta::Tuple{T, T}
   epsilon::T
 end
-NADAM(η = 0.001, β = (0.9, 0.999), ϵ = eps(typeof(η))) = NADAM(η, β, ϵ)
+NADAM(η = 1f-3, β = (9f-1, 9.99f-1), ϵ = eps(typeof(η))) = NADAM(η, β, ϵ)
 
 init(o::NADAM, x::AbstractArray) = (zero(x), zero(x), o.beta)
 
@@ -415,7 +415,7 @@ function apply(o::NADAM, x, dx, state)
 end
 
 """
-    ADAMW(η = 0.001, β = (0.9, 0.999), γ = 0, ϵ = eps(typeof(η)))
+    ADAMW(η = 1f-3, β = (9f-1, 9.99f-1), γ = 0, ϵ = eps(typeof(η)))
 
 [ADAMW](https://arxiv.org/abs/1711.05101) is a variant of ADAM fixing (as in repairing) its
 weight decay regularization.
@@ -429,11 +429,11 @@ weight decay regularization.
 - Machine epsilon (`ϵ`): Constant to prevent division by zero
                          (no need to change default)
 """
-ADAMW(η = 0.001, β = (0.9, 0.999), γ = 0, ϵ = eps(typeof(η))) =
+ADAMW(η = 1f-3, β = (9f-1, 9.99f-1), γ = 0, ϵ = eps(typeof(η))) =
   SequenceOptimiser(ADAM(η, β, ϵ), WeightDecay(γ))
 
 """
-    AdaBelief(η = 0.001, β = (0.9, 0.999), ϵ = eps(typeof(η)))
+    AdaBelief(η = 1f-3, β = (9f-1, 9.99f-1), ϵ = eps(typeof(η)))
 
 The [AdaBelief](https://arxiv.org/abs/2010.07468) optimiser is a variant of the well-known
 ADAM optimiser.
@@ -451,7 +451,7 @@ struct AdaBelief{T}
   beta::Tuple{T, T}
   epsilon::T
 end
-AdaBelief(η = 0.001, β = (0.9, 0.999), ϵ = eps(typeof(η))) = AdaBelief(η, β, ϵ)
+AdaBelief(η = 1f-3, β = (9f-1, 9.99f-1), ϵ = eps(typeof(η))) = AdaBelief(η, β, ϵ)
 
 init(o::AdaBelief, x::AbstractArray) = (zero(x), zero(x))
 
@@ -469,7 +469,7 @@ function apply(o::AdaBelief, x, dx, state)
 end
 
 """
-    WeightDecay(γ = 0)
+    WeightDecay(γ = 5f-4)
 
 Decay weights by `γ`.
 
@@ -479,7 +479,7 @@ Decay weights by `γ`.
 struct WeightDecay{T}
   wd::T
 end
-WeightDecay() = WeightDecay(1e-4)
+WeightDecay() = WeightDecay(5f-4)
 
 init(o::WeightDecay, x::AbstractArray) = nothing
 

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -39,7 +39,7 @@ struct Momentum{T}
   eta::T
   rho::T
 end
-Momentum(η = 1f-2, ρ = 9f-1) = Momentum(η, ρ)
+Momentum(η = 1f-2, ρ = 9f-1) = Momentum{typeof(η)}(η, ρ)
 
 init(o::Momentum, x::AbstractArray) = zero(x)
 
@@ -67,7 +67,7 @@ struct Nesterov{T}
   eta::T
   rho::T
 end
-Nesterov(η = 1f-3, ρ = 9f-1) = Nesterov(η, ρ)
+Nesterov(η = 1f-3, ρ = 9f-1) = Nesterov{typeof(η)}(η, ρ)
 
 init(o::Nesterov, x::AbstractArray) = zero(x)
 
@@ -102,7 +102,7 @@ struct RMSProp{T}
   rho::T
   epsilon::T
 end
-RMSProp(η = 1f-3, ρ = 9f-1, ϵ = eps(typeof(η))) = RMSProp(η, ρ, ϵ)
+RMSProp(η = 1f-3, ρ = 9f-1, ϵ = eps(typeof(η))) = RMSProp{typeof(η)}(η, ρ, ϵ)
 
 init(o::RMSProp, x::AbstractArray) = zero(x)
 
@@ -134,7 +134,7 @@ struct ADAM{T}
   beta::Tuple{T, T}
   epsilon::T
 end
-ADAM(η = 1f-3, β = (9f-1, 9.99f-1), ϵ = eps(typeof(η))) = ADAM(η, β, ϵ)
+ADAM(η = 1f-3, β = (9f-1, 9.99f-1), ϵ = eps(typeof(η))) = ADAM{typeof(η)}(η, β, ϵ)
 
 init(o::ADAM, x::AbstractArray) = (zero(x), zero(x), o.beta)
 
@@ -169,7 +169,7 @@ struct RADAM{T}
   beta::Tuple{T, T}
   epsilon::T
 end
-RADAM(η = 1f-3, β = (9f-1, 9.99f-1), ϵ = eps(typeof(η))) = RADAM(η, β, ϵ)
+RADAM(η = 1f-3, β = (9f-1, 9.99f-1), ϵ = eps(typeof(η))) = RADAM{typeof(η)}(η, β, ϵ)
 
 init(o::RADAM, x::AbstractArray) = (zero(x), zero(x), o.beta, 1)
 
@@ -212,7 +212,7 @@ struct AdaMax{T}
   beta::Tuple{T, T}
   epsilon::T
 end
-AdaMax(η = 1f-3, β = (9f-1, 9.99f-1), ϵ = eps(typeof(η))) = AdaMax(η, β, ϵ)
+AdaMax(η = 1f-3, β = (9f-1, 9.99f-1), ϵ = eps(typeof(η))) = AdaMax{typeof(η)}(η, β, ϵ)
 
 init(o::AdaMax, x::AbstractArray) = (zero(x), zero(x), o.beta)
 
@@ -249,7 +249,7 @@ struct OADAM{T}
   beta::Tuple{T, T}
   epsilon::T
 end
-OADAM(η = 1f-3, β = (5f-1, 9f-1), ϵ = eps(typeof(η))) = OADAM(η, β, ϵ)
+OADAM(η = 1f-3, β = (5f-1, 9f-1), ϵ = eps(typeof(η))) = OADAM{typeof(η)}(η, β, ϵ)
 
 init(o::OADAM, x::AbstractArray) = (zero(x), zero(x), o.beta, zero(x))
 
@@ -286,7 +286,7 @@ struct ADAGrad{T}
   eta::T
   epsilon::T
 end
-ADAGrad(η = 1f-1, ϵ = eps(typeof(η))) = ADAGrad(η, ϵ)
+ADAGrad(η = 1f-1, ϵ = eps(typeof(η))) = ADAGrad{typeof(η)}(η, ϵ)
 
 init(o::ADAGrad, x::AbstractArray) = fill!(similar(x), o.epsilon)
 
@@ -318,7 +318,7 @@ struct ADADelta{T}
   rho::T
   epsilon::T
 end
-ADADelta(ρ = 9f-1, ϵ = eps(typeof(ρ))) = ADADelta(ρ, ϵ)
+ADADelta(ρ = 9f-1, ϵ = eps(typeof(ρ))) = ADADelta{typeof(ρ)}(ρ, ϵ)
 
 init(o::ADADelta, x::AbstractArray) = (zero(x), zero(x))
 
@@ -356,7 +356,7 @@ struct AMSGrad{T}
   beta::Tuple{T, T}
   epsilon::T
 end
-AMSGrad(η = 1f-3, β = (9f-1, 9.99f-1), ϵ = eps(typeof(η))) = AMSGrad(η, β, ϵ)
+AMSGrad(η = 1f-3, β = (9f-1, 9.99f-1), ϵ = eps(typeof(η))) = AMSGrad{typeof(η)}(η, β, ϵ)
 
 init(o::AMSGrad, x::AbstractArray) =
   (fill!(similar(x), o.epsilon), fill!(similar(x), o.epsilon), fill!(similar(x), o.epsilon))
@@ -395,7 +395,7 @@ struct NADAM{T}
   beta::Tuple{T, T}
   epsilon::T
 end
-NADAM(η = 1f-3, β = (9f-1, 9.99f-1), ϵ = eps(typeof(η))) = NADAM(η, β, ϵ)
+NADAM(η = 1f-3, β = (9f-1, 9.99f-1), ϵ = eps(typeof(η))) = NADAM{typeof(η)}(η, β, ϵ)
 
 init(o::NADAM, x::AbstractArray) = (zero(x), zero(x), o.beta)
 
@@ -430,7 +430,7 @@ weight decay regularization.
                          (no need to change default)
 """
 ADAMW(η = 1f-3, β = (9f-1, 9.99f-1), γ = 0, ϵ = eps(typeof(η))) =
-  OptimiserChain(ADAM(η, β, ϵ), WeightDecay(γ))
+  OptimiserChain(ADAM{typeof(η)}(η, β, ϵ), WeightDecay(γ))
 
 """
     AdaBelief(η = 1f-3, β = (9f-1, 9.99f-1), ϵ = eps(typeof(η)))
@@ -451,7 +451,7 @@ struct AdaBelief{T}
   beta::Tuple{T, T}
   epsilon::T
 end
-AdaBelief(η = 1f-3, β = (9f-1, 9.99f-1), ϵ = eps(typeof(η))) = AdaBelief(η, β, ϵ)
+AdaBelief(η = 1f-3, β = (9f-1, 9.99f-1), ϵ = eps(typeof(η))) = AdaBelief{typeof(η)}(η, β, ϵ)
 
 init(o::AdaBelief, x::AbstractArray) = (zero(x), zero(x))
 

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -430,7 +430,7 @@ weight decay regularization.
                          (no need to change default)
 """
 ADAMW(η = 1f-3, β = (9f-1, 9.99f-1), γ = 0, ϵ = eps(typeof(η))) =
-  ChainOptimiser(ADAM(η, β, ϵ), WeightDecay(γ))
+  OptimiserChain(ADAM(η, β, ϵ), WeightDecay(γ))
 
 """
     AdaBelief(η = 1f-3, β = (9f-1, 9.99f-1), ϵ = eps(typeof(η)))
@@ -492,21 +492,21 @@ function apply(o::WeightDecay, x, dx, state)
 end
 
 """
-    ChainOptimiser(opts...)
+    OptimiserChain(opts...)
 
 Compose a chain (sequence) of optimisers so that each `opt` in `opts`
 updates the gradient in the order specified.
 """
-struct ChainOptimiser{O}
+struct OptimiserChain{O}
   opts::O
 end
-ChainOptimiser(opts...) = ChainOptimiser(opts)
+OptimiserChain(opts...) = OptimiserChain(opts)
 
-init(o::ChainOptimiser, x::AbstractArray) = [init(opt, x) for opt in o.opts]
+init(o::OptimiserChain, x::AbstractArray) = [init(opt, x) for opt in o.opts]
 
-(o::ChainOptimiser)(m, dm, state) = update(o, m, dm, state)
+(o::OptimiserChain)(m, dm, state) = update(o, m, dm, state)
 
-function apply(o::ChainOptimiser, x, dx, states)
+function apply(o::OptimiserChain, x, dx, states)
   new_states = similar(states)
   for (i, (opt, state)) in enumerate(zip(o.opts, states))
     dx, new_states[i] = apply(opt, x, dx, state)

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -10,7 +10,7 @@ For each parameter `p` and its gradient `dp`, this runs `p -= η*dp`.
 - Learning rate (`η`): Amount by which gradients are discounted before updating
                        the weights.
 """
-mutable struct Descent{T}
+struct Descent{T}
   eta::T
 end
 Descent(; η = 0.1) = Descent(η)
@@ -37,7 +37,7 @@ Gradient descent optimizer with learning rate `η` and momentum `ρ`.
 - Momentum (`ρ`): Controls the acceleration of gradient descent in the
                   prominent direction, in effect dampening oscillations.
 """
-mutable struct Momentum{T,S}
+struct Momentum{T,S}
   eta::T
   rho::S
 end
@@ -65,7 +65,7 @@ Gradient descent optimizer with learning rate `η` and Nesterov momentum `ρ`.
 - Nesterov momentum (`ρ`): Controls the acceleration of gradient descent in the
                            prominent direction, in effect dampening oscillations.
 """
-mutable struct Nesterov{T,S}
+struct Nesterov{T,S}
   eta::T
   rho::S
 end
@@ -99,7 +99,7 @@ generally don't need tuning.
 - Machine epsilon (`ϵ::Float32`): Constant to prevent division by zero
                   (no need to change default)
 """
-mutable struct RMSProp{T,S}
+struct RMSProp{T,S}
   eta::T
   rho::S
   epsilon::Float32
@@ -131,7 +131,7 @@ end
 - Machine epsilon (`ϵ::Float32`): Constant to prevent division by zero
                                   (no need to change default)
 """
-mutable struct ADAM{T,K}
+struct ADAM{T,K}
   eta::T
   beta::Tuple{K,K}
   epsilon::Float32
@@ -166,7 +166,7 @@ end
 - Machine epsilon (`ϵ::Float32`): Constant to prevent division by zero
                                   (no need to change default)
 """
-mutable struct RADAM{T,S}
+struct RADAM{T,S}
   eta::T
   beta::Tuple{S,S}
   epsilon::Float32
@@ -210,7 +210,7 @@ end
 - Machine epsilon (`ϵ::Float32`): Constant to prevent division by zero
                                   (no need to change default)
 """
-mutable struct AdaMax{T,S}
+struct AdaMax{T,S}
   eta::T
   beta::Tuple{S,S}
   epsilon::Float32
@@ -248,7 +248,7 @@ is a variant of ADAM adding an "optimistic" term suitable for adversarial traini
 - Machine epsilon (`ϵ::Float32`): Constant to prevent division by zero
                                   (no need to change default)
 """
-mutable struct OADAM{T,S}
+struct OADAM{T,S}
   eta::T
   beta::Tuple{S,S}
   epsilon::Float32
@@ -287,7 +287,7 @@ Parameters don't need tuning.
 - Machine epsilon (`ϵ::Float32`): Constant to prevent division by zero
                                   (no need to change default)
 """
-mutable struct ADAGrad{T}
+struct ADAGrad{T}
   eta::T
   epsilon::Float32
 end
@@ -319,7 +319,7 @@ Parameters don't need tuning.
 - Machine epsilon (`ϵ::Float32`): Constant to prevent division by zero
                                   (no need to change default)
 """
-mutable struct ADADelta{T}
+struct ADADelta{T}
   rho::T
   epsilon::Float32
 end
@@ -356,7 +356,7 @@ optimiser. Parameters don't need tuning.
 - Machine epsilon (`ϵ::Float32`): Constant to prevent division by zero
                                   (no need to change default)
 """
-mutable struct AMSGrad{T,S}
+struct AMSGrad{T,S}
   eta::T
   beta::Tuple{S,S}
   epsilon::Float32
@@ -395,7 +395,7 @@ Parameters don't need tuning.
 - Machine epsilon (`ϵ::Float32`): Constant to prevent division by zero
                                   (no need to change default)
 """
-mutable struct NADAM{T,S}
+struct NADAM{T,S}
   eta::T
   beta::Tuple{S,S}
   epsilon::Float32
@@ -452,7 +452,7 @@ ADAM optimiser.
 - Machine epsilon (`ϵ::Float32`): Constant to prevent division by zero
                                   (no need to change default)
 """
-mutable struct AdaBelief{T,S}
+struct AdaBelief{T,S}
   eta::T
   beta::Tuple{S,S}
   epsilon::Float32
@@ -482,7 +482,7 @@ Decay weights by `wd`.
 # Parameters
 - Weight decay (`γ`)
 """
-mutable struct WeightDecay{T}
+struct WeightDecay{T}
   wd::T
 end
 WeightDecay(; γ = 1e-4) = WeightDecay(γ)
@@ -513,9 +513,10 @@ init(o::SequenceOptimiser, x::AbstractArray) = [init(opt, x) for opt in o.opts]
 (o::SequenceOptimiser)(m, dm, state) = update(o, m, dm, state)
 
 function apply(o::SequenceOptimiser, x, dx, states)
+  new_states = similar(states)
   for (i, (opt, state)) in enumerate(zip(o.opts, states))
-    dx, states[i] = apply(opt, x, dx, state)
+    dx, new_states[i] = apply(opt, x, dx, state)
   end
 
-  return dx, states
+  return dx, new_states
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,7 +9,7 @@ using Statistics
                      ADAGrad(), AdaMax(), ADADelta(), AMSGrad(), NADAM(),
                      ADAMW(), RADAM(), OADAM(), AdaBelief())
     w = (α = rand(3, 3), β = rand(3, 3))
-    st = Optimisers.init(o, w)
+    st = Optimisers.state(o, w)
     loss(x, y) = mean((x.α .* x.β .- y.α .* y.β) .^ 2)
     l = loss(w, w′)
     for i = 1:10^4

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,7 +9,7 @@ using Statistics
                      ADAGrad(), AdaMax(), ADADelta(), AMSGrad(), NADAM(),
                      ADAMW(), RADAM(), OADAM(), AdaBelief())
     w = (α = rand(3, 3), β = rand(3, 3))
-    st = init(o, w)
+    st = Optimisers.init(o, w)
     loss(x, y) = mean((x.α .* x.β .- y.α .* y.β) .^ 2)
     l = loss(w, w′)
     for i = 1:10^4

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,5 +18,19 @@ using Statistics
     end
     @test loss(w, w′) < 0.01
   end
+end
 
+@testset "OptimiserChain" begin
+  Random.seed!(84)
+  w = randn(10, 10)
+  w′ = randn(10, 10)
+  loss(x, w, w′) = mean((w*x .- w′*x) .^ 2)
+  opt = OptimiserChain(WeightDecay(), ADAM(0.001))
+  st = Optimisers.state(opt, w)
+  for t = 1:10^5
+    x = rand(10)
+    gs = gradient(w -> loss(x, w, w′), w)
+    w, st = Optimisers.update(opt, w, gs..., st)
+  end
+  @test loss(rand(10, 10), w, w′) < 0.01
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,7 +5,9 @@ using Statistics
 @testset "Optimisers" begin
   Random.seed!(84)
   w′ = (α = rand(3, 3), β = rand(3, 3))
-  @testset for o in (Descent(), Momentum(), Nesterov(), RMSProp(), ADAM())
+  @testset for o in (Descent(), ADAM(), Momentum(), Nesterov(), RMSProp(),
+                     ADAGrad(), AdaMax(), ADADelta(), AMSGrad(), NADAM(),
+                     ADAMW(), RADAM(), OADAM(), AdaBelief())
     w = (α = rand(3, 3), β = rand(3, 3))
     st = init(o, w)
     loss(x, y) = mean((x.α .* x.β .- y.α .* y.β) .^ 2)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,15 +4,14 @@ using Statistics
 
 @testset "Optimisers" begin
   Random.seed!(84)
-  w′ = rand(3,3)
-  @testset for o in (Descent(0.1), Momentum(0.01, 0.9), Nesterov(0.001, 0.9), RMSProp(0.001, 0.9),
-                     ADAM(0.001, (0.9, 0.99)))
-    w = rand(3,3)
-    st = Optimisers.init(o,w)
-    loss(x, y) = mean((x .- y) .^ 2)
+  w′ = (α = rand(3, 3), β = rand(3, 3))
+  @testset for o in (Descent(), Momentum(), Nesterov(), RMSProp(), ADAM())
+    w = (α = rand(3, 3), β = rand(3, 3))
+    st = init(o, w)
+    loss(x, y) = mean((x.α .* x.β .- y.α .* y.β) .^ 2)
     l = loss(w, w′)
     for i = 1:10^4
-      gs = gradient(x -> loss(x,w′), w)
+      gs = gradient(x -> loss(x, w′), w)
       w, st = o(w, gs..., st)
     end
     @test loss(w, w′) < 0.01


### PR DESCRIPTION
This PR finishes the already good work in this repo to move all the optimizers from Flux to Optimisers.jl. The main advantage of the implementation in Optimisers.jl is the use of functors and explicit state. This eliminates the need for any `IdDict`s and simplifies how compositions of basic optimizers work.

~~One notable exception: this implementation is mutable. The simple reason for this is that immutable updates will copy entire models and result in high memory usage. Until we have a compiler optimization to address this, this PR opts to have mutable updates for now. You can read more about the reasoning [in this design note](https://github.com/FluxML/ML-Coordination-Tracker/discussions/22).~~

Remaining tasks:
- [x] docstrings
- [x] clean up tests

cc @DhairyaLGandhi @CarloLucibello @mcabbott @ToucheSir 