### PR TITLE
RFC: basic sketch of scheduling

### DIFF
--- a/src/schedulers.jl
+++ b/src/schedulers.jl
@@ -1,0 +1,47 @@
+f(t, p) = (2 / π) * abs(asin(sin(π * (t - 1) / p)))
+sine(t, p = 1.) = (2 / π) * abs(asin(sin(π * (t - 1) / p)))
+sine(p) = t -> (2 / Float32(π)) * abs(asin(sin(Float32(π) * (t - 1) / p)))
+
+mutable struct Schedule{O,F}
+  f::F
+  opt::O
+  cursor::Float32
+  # cursor_step::Float64
+end
+
+function Schedule(f, opt)
+  Schedule(f, opt, 1.f0 + eps(Float32)) 
+end
+
+
+# Timestep: t - always depends on run
+# Phase: p - mostly likely constant
+
+# What we want to "schedule" - everything (so will have to let people mess with things)
+# Most likely learning rate
+# If `f` relies on only time - it can be generated on the fly
+
+function next(s::Schedule{O}, (cursor, cursor_step)) where O
+  cursor += cursor_step
+  ADAM(s.opt, eta = s.f(cursor) * s.opt.eta) #replace with O(..)
+end
+
+init(f, x) = (1.f0, 0.1f0)
+init(s::Schedule, x) = (init(s.f, x), init(s.opt, x))
+
+function apply(s::Schedule, x, dx, st)
+  schedst, optst = st
+  o = next(s, schedst)
+  # @show o
+  Δ, optst2 = apply(o, x, dx, optst)
+  Δ, ((cursor .+ cursor_step, cursor_step), optst2)
+end
+
+struct InvDecay{T}
+  decay::T
+end
+
+init(inv::InvDecay, x) = (1, 1)
+(inv::InvDecay)(t) = 1 / (1 + inv.decay * t)
+
+InvDecay(s = 0.1f0) = InvDecay{typeof(s)}(s)

--- a/src/schedulers.jl
+++ b/src/schedulers.jl
@@ -1,14 +1,24 @@
-f(t, p) = (2 / π) * abs(asin(sin(π * (t - 1) / p)))
-sine(t, p = 1.) = (2 / π) * abs(asin(sin(π * (t - 1) / p)))
+# f(t, p) = (2 / π) * abs(asin(sin(π * (t - 1) / p)))
+# sine(t, p = 1.) = (2 / π) * abs(asin(sin(π * (t - 1) / p)))
+
+# Simple scheduling can happen as a basic closure.
 sine(p) = t -> (2 / Float32(π)) * abs(asin(sin(Float32(π) * (t - 1) / p)))
 
 mutable struct Schedule{O,F}
   f::F
   opt::O
   cursor::Float32
-  # cursor_step::Float64
 end
 
+"""
+    Schedule(f, opt)
+
+Create a scheduled optimiser whose update rule is controlled by `f`.
+
+`f` can be any callable, while `opt` can be any optimiser.
+
+See also [next](@ref), [init](@ref)
+"""
 function Schedule(f, opt)
   Schedule(f, opt, 1.f0 + eps(Float32)) 
 end
@@ -21,6 +31,14 @@ end
 # Most likely learning rate
 # If `f` relies on only time - it can be generated on the fly
 
+"""
+    next(s::Schedule, state)
+
+Returns a new optimiser as described by the scheduler function
+and the optimiser. This allocates a new optimiser on the stack, keeping the original one intact.
+
+The state is a tuple of the state as defined by the scheduling function.
+"""
 function next(s::Schedule{O}, (cursor, cursor_step)) where O
   cursor += cursor_step
   ADAM(s.opt, eta = s.f(cursor) * s.opt.eta) #replace with O(..)
@@ -32,7 +50,6 @@ init(s::Schedule, x) = (init(s.f, x), init(s.opt, x))
 function apply(s::Schedule, x, dx, st)
   schedst, optst = st
   o = next(s, schedst)
-  # @show o
   Δ, optst2 = apply(o, x, dx, optst)
   Δ, ((cursor .+ cursor_step, cursor_step), optst2)
 end
@@ -45,3 +62,5 @@ init(inv::InvDecay, x) = (1, 1)
 (inv::InvDecay)(t) = 1 / (1 + inv.decay * t)
 
 InvDecay(s = 0.1f0) = InvDecay{typeof(s)}(s)
+
+

--- a/src/schedulers.jl
+++ b/src/schedulers.jl
@@ -1,8 +1,15 @@
+using Base.Iterators: Cycle, Zip, Stateful,
+                      Repeated, Take, TakeWhile
+
 # f(t, p) = (2 / π) * abs(asin(sin(π * (t - 1) / p)))
 # sine(t, p = 1.) = (2 / π) * abs(asin(sin(π * (t - 1) / p)))
 
 # Simple scheduling can happen as a basic closure.
 triangle(t) = (1 - 2 * abs(round(Int, t/2) - t/2))
+
+const BaseIterators = Union{Cycle, Zip,
+                            Stateful, Repeated,
+                            Take, TakeWhile}
 
 mutable struct Schedule{O,F}
   f::F
@@ -23,7 +30,6 @@ function Schedule(f, opt)
   Schedule(f, opt, 1.f0 + eps(Float32)) 
 end
 
-
 # Timestep: t - always depends on run
 # Phase: p - mostly likely constant
 
@@ -31,26 +37,44 @@ end
 # Most likely learning rate
 # If `f` relies on only time - it can be generated on the fly
 
+# st = (t, timestep)
+function next(itr::T, st) where T <: BaseIterators
+  t, ts = st
+  @show st
+  iterate(itr, ts)
+end
+
+function next(arr::T, st) where T
+  t, ts = st
+  iterate(arr, ts)
+end
+
+next(f, (t,ts)) = f(t .+ ts), (t .+ ts, ts)
+
+next_opt(o::T, kwargs...) where T = T(o, kwargs...)
+
 """
     next(s::Schedule, state)
 
 Returns a new optimiser as described by the scheduler function
 and the optimiser. This allocates a new optimiser on the stack, keeping the original one intact.
 
-The state is a tuple of the state as defined by the scheduling function.
+The state is a tuple of the state as defined by the scheduling policy.
 """
-function next(s::Schedule{O}, (cursor, cursor_step)) where O
-  cursor += cursor_step
-  ADAM(s.opt, eta = s.f(cursor) * s.opt.eta), (cursor .+ cursor_step, cursor_step) #replace with O(..)
+function next(s::Schedule{O}, st) where O
+  snew, schedst = next(s.f, st)
+  @show schedst
+  ADAM(s.opt, eta = snew * s.opt.eta), (snew, schedst) #replace with O(..)
 end
 
-init(f, x) = (1.f0, 0.1f0)
+init(f, x) = (1, 1)
+init(itr::T, x) where T <: BaseIterators = iterate(itr)
 init(s::Schedule, x) = (init(s.f, x), init(s.opt, x))
 
 function apply(s::Schedule, x, dx, st)
   schedst, optst = st
-  # cursor, cursor_step = schedst
   o, schedst2 = next(s, schedst)
+  @show o
   Δ, optst2 = apply(o, x, dx, optst)
   Δ, (schedst2, optst2)
 end
@@ -60,7 +84,6 @@ struct InvDecay{T}
 end
 
 # (start, step) -> consider step to be a function/ vector of step sizes?
-init(inv::InvDecay, x) = (1, 1)
 (inv::InvDecay)(t) = 1 / (1 + inv.decay * t)
 
 InvDecay(s = 0.1f0) = InvDecay{typeof(s)}(s)

--- a/src/schedulers.jl
+++ b/src/schedulers.jl
@@ -2,7 +2,7 @@
 # sine(t, p = 1.) = (2 / π) * abs(asin(sin(π * (t - 1) / p)))
 
 # Simple scheduling can happen as a basic closure.
-sine(p) = t -> (2 / Float32(π)) * abs(asin(sin(Float32(π) * (t - 1) / p)))
+triangle(t) = (1 - 2 * abs(round(Int, t/2) - t/2))
 
 mutable struct Schedule{O,F}
   f::F
@@ -49,6 +49,7 @@ init(s::Schedule, x) = (init(s.f, x), init(s.opt, x))
 
 function apply(s::Schedule, x, dx, st)
   schedst, optst = st
+  cursor, cursor_step = schedst
   o = next(s, schedst)
   Δ, optst2 = apply(o, x, dx, optst)
   Δ, ((cursor .+ cursor_step, cursor_step), optst2)
@@ -63,4 +64,4 @@ init(inv::InvDecay, x) = (1, 1)
 
 InvDecay(s = 0.1f0) = InvDecay{typeof(s)}(s)
 
-
+sine(p) = t -> sin(Float32(π) * t / p)

--- a/src/schedulers.jl
+++ b/src/schedulers.jl
@@ -41,7 +41,7 @@ The state is a tuple of the state as defined by the scheduling function.
 """
 function next(s::Schedule{O}, (cursor, cursor_step)) where O
   cursor += cursor_step
-  ADAM(s.opt, eta = s.f(cursor) * s.opt.eta) #replace with O(..)
+  ADAM(s.opt, eta = s.f(cursor) * s.opt.eta), (cursor .+ cursor_step, cursor_step) #replace with O(..)
 end
 
 init(f, x) = (1.f0, 0.1f0)
@@ -49,16 +49,17 @@ init(s::Schedule, x) = (init(s.f, x), init(s.opt, x))
 
 function apply(s::Schedule, x, dx, st)
   schedst, optst = st
-  cursor, cursor_step = schedst
-  o = next(s, schedst)
+  # cursor, cursor_step = schedst
+  o, schedst2 = next(s, schedst)
   Δ, optst2 = apply(o, x, dx, optst)
-  Δ, ((cursor .+ cursor_step, cursor_step), optst2)
+  Δ, (schedst2, optst2)
 end
 
 struct InvDecay{T}
   decay::T
 end
 
+# (start, step) -> consider step to be a function/ vector of step sizes?
 init(inv::InvDecay, x) = (1, 1)
 (inv::InvDecay)(t) = 1 / (1 + inv.decay * t)
 


### PR DESCRIPTION
@darsnack (whose ParametersSchedule.jl has implemented a bunch of these and I tried to understand the different design choices of those) one concern that I do have is that we don't have much of a view in the running stats of a training loop in this abstraction.

We also want to generally eliminate a state as part of the scheduler, which adds an extra line to the apply function. We generally have a decent view of how to implement a bunch of different routines with this. It allows a few different kinds of callables, and there's usually little boilerplate.

It would look something like

`Schedule(InvDecay(0.5f0), ADAM())`

Or

`Schedule(sine(0.5f0), opt)`

We would also want to think of standard schedules to introduce. We can customise working with apply and next which is a clean separation of concern with this.