### PR TITLE
RFC: Switch interface for higher-order optimizers

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -9,20 +9,20 @@ function state(o, x)
   end
 end
 
-function _update(o, x, x̄, st)
-  x̄, st = apply(o, x, x̄, st)
+function _update(o, st, x, x̄)
+  x̄, st = apply(o, st, x, x̄)
   return patch(x, x̄), st
 end
 
-function update(o, x::T, x̄, state) where T
+function update(o, state, x::T, x̄) where T
   if x̄ === nothing
     return x, state
   elseif isleaf(x)
-    return _update(o, x, x̄, state)
+    return _update(o, state, x, x̄)
   else
     x̄, _  = functor(typeof(x), x̄)
     x, restructure = functor(typeof(x), x)
-    xstate = map((x, x̄, state) -> update(o, x, x̄, state), x, x̄, state)
+    xstate = map((x, x̄, state) -> update(o, state, x, x̄), x, x̄, state)
     return restructure(map(first, xstate)), map(x -> x[2], xstate)
   end
 end

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -15,13 +15,13 @@ Descent() = Descent(1f-1)
 
 init(o::Descent, x::AbstractArray) = nothing
 
-function apply(o::Descent, x, dx, state)
+function apply(o::Descent, state, x, dx)
   η = convert(eltype(dx), o.eta)
   
   return dx .* η, state
 end
 
-(o::Descent)(m, dm, st) = update(o, m, dm, st)
+(o::Descent)(state, m, dm) = update(o, state, m, dm)
 
 """
     Momentum(η = 1f-2, ρ = 9f-1)
@@ -42,14 +42,14 @@ Momentum(η = 1f-2, ρ = 9f-1) = Momentum{typeof(η)}(η, ρ)
 
 init(o::Momentum, x::AbstractArray) = zero(x)
 
-function apply(o::Momentum, x, dx, state)
+function apply(o::Momentum, state, x, dx)
   η, ρ, v = o.eta, o.rho, state
   @. v = ρ * v - η * dx
   
   return -v, v
 end
 
-(o::Momentum)(m, dm, state) = update(o, m, dm, state)
+(o::Momentum)(state, m, dm) = update(o, state, m, dm)
 
 """
     Nesterov(η = 1f-3, ρ = 9f-1)
@@ -70,9 +70,9 @@ Nesterov(η = 1f-3, ρ = 9f-1) = Nesterov{typeof(η)}(η, ρ)
 
 init(o::Nesterov, x::AbstractArray) = zero(x)
 
-(o::Nesterov)(m, dm, state) = update(o, m, dm, state)
+(o::Nesterov)(state, m, dm) = update(o, state, m, dm)
 
-function apply(o::Nesterov, x, dx, state)
+function apply(o::Nesterov, state, x, dx)
   η, ρ, v = o.eta, o.rho, state
   d = @. ρ^2 * v - (1+ρ) * η * dx
   @. v = ρ * v - η * dx
@@ -105,7 +105,7 @@ RMSProp(η = 1f-3, ρ = 9f-1, ϵ = eps(typeof(η))) = RMSProp{typeof(η)}(η, ρ
 
 init(o::RMSProp, x::AbstractArray) = zero(x)
 
-function apply(o::RMSProp, x, dx, state)
+function apply(o::RMSProp, state, x, dx)
   η, ρ, ϵ, acc = o.eta, o.rho, o.epsilon, state
   @. acc = ρ * acc + (1 - ρ) * dx^2
   dx = @. dx * (η / (sqrt(acc) + ϵ))
@@ -113,7 +113,7 @@ function apply(o::RMSProp, x, dx, state)
   return dx, acc
 end
 
-(o::RMSProp)(m, dm, state) = update(o, m, dm, state)
+(o::RMSProp)(state, m, dm) = update(o, state, m, dm)
 
 """
     ADAM(η = 1f-3, β = (9f-1, 9.99f-1), ϵ = eps(typeof(η)))
@@ -137,9 +137,9 @@ ADAM(η = 1f-3, β = (9f-1, 9.99f-1), ϵ = eps(typeof(η))) = ADAM{typeof(η)}(�
 
 init(o::ADAM, x::AbstractArray) = (zero(x), zero(x), o.beta)
 
-(o::ADAM)(m, dm, state) = update(o, m, dm, state)
+(o::ADAM)(state, m, dm) = update(o, state, m, dm)
 
-function apply(o::ADAM{T}, x, dx, state) where T
+function apply(o::ADAM{T}, state, x, dx) where T
   η, β, ϵ = o.eta, o.beta, o.epsilon
   mt, vt, βt = state
 
@@ -172,9 +172,9 @@ RADAM(η = 1f-3, β = (9f-1, 9.99f-1), ϵ = eps(typeof(η))) = RADAM{typeof(η)}
 
 init(o::RADAM, x::AbstractArray) = (zero(x), zero(x), o.beta, 1)
 
-(o::RADAM)(m, dm, state) = update(o, m, dm, state)
+(o::RADAM)(state, m, dm) = update(o, state, m, dm)
 
-function apply(o::RADAM, x, dx, state)
+function apply(o::RADAM, state, x, dx)
   η, β, ϵ = o.eta, o.beta, o.epsilon
   ρ∞ = 2/(1-β[2])-1
 
@@ -215,9 +215,9 @@ AdaMax(η = 1f-3, β = (9f-1, 9.99f-1), ϵ = eps(typeof(η))) = AdaMax{typeof(η
 
 init(o::AdaMax, x::AbstractArray) = (zero(x), zero(x), o.beta)
 
-(o::AdaMax)(m, dm, state) = update(o, m, dm, state)
+(o::AdaMax)(state, m, dm) = update(o, state, m, dm)
 
-function apply(o::AdaMax, x, dx, state)
+function apply(o::AdaMax, state, x, dx)
   η, β, ϵ = o.eta, o.beta, o.epsilon
 
   mt, ut, βt = state
@@ -252,9 +252,9 @@ OADAM(η = 1f-3, β = (5f-1, 9f-1), ϵ = eps(typeof(η))) = OADAM{typeof(η)}(η
 
 init(o::OADAM, x::AbstractArray) = (zero(x), zero(x), o.beta, zero(x))
 
-(o::OADAM)(m, dm, state) = update(o, m, dm, state)
+(o::OADAM)(state, m, dm) = update(o, state, m, dm)
 
-function apply(o::OADAM, x, dx, state)
+function apply(o::OADAM, state, x, dx)
   η, β, ϵ = o.eta, o.beta, o.epsilon
 
   mt, vt, βt, dx_ = state
@@ -289,9 +289,9 @@ ADAGrad(η = 1f-1, ϵ = eps(typeof(η))) = ADAGrad{typeof(η)}(η, ϵ)
 
 init(o::ADAGrad, x::AbstractArray) = fill!(similar(x), o.epsilon)
 
-(o::ADAGrad)(m, dm, state) = update(o, m, dm, state)
+(o::ADAGrad)(state, m, dm) = update(o, state, m, dm)
 
-function apply(o::ADAGrad, x, dx, state)
+function apply(o::ADAGrad, state, x, dx)
   η, ϵ = o.eta, o.epsilon
   acc = state
 
@@ -321,9 +321,9 @@ ADADelta(ρ = 9f-1, ϵ = eps(typeof(ρ))) = ADADelta{typeof(ρ)}(ρ, ϵ)
 
 init(o::ADADelta, x::AbstractArray) = (zero(x), zero(x))
 
-(o::ADADelta)(m, dm, state) = update(o, m, dm, state)
+(o::ADADelta)(state, m, dm) = update(o, state, m, dm)
 
-function apply(o::ADADelta, x, dx, state)
+function apply(o::ADADelta, state, x, dx)
   ρ, ϵ = o.rho, o.epsilon
   acc, Δacc = state
 
@@ -360,9 +360,9 @@ AMSGrad(η = 1f-3, β = (9f-1, 9.99f-1), ϵ = eps(typeof(η))) = AMSGrad{typeof(
 init(o::AMSGrad, x::AbstractArray) =
   (fill!(similar(x), o.epsilon), fill!(similar(x), o.epsilon), fill!(similar(x), o.epsilon))
 
-(o::AMSGrad)(m, dm, state) = update(o, m, dm, state)
+(o::AMSGrad)(state, m, dm) = update(o, state, m, dm)
 
-function apply(o::AMSGrad, x, dx, state)
+function apply(o::AMSGrad, state, x, dx)
   η, β, ϵ = o.eta, o.beta, o.epsilon
 
   mt, vt, v̂t = state
@@ -398,9 +398,9 @@ NADAM(η = 1f-3, β = (9f-1, 9.99f-1), ϵ = eps(typeof(η))) = NADAM{typeof(η)}
 
 init(o::NADAM, x::AbstractArray) = (zero(x), zero(x), o.beta)
 
-(o::NADAM)(m, dm, state) = update(o, m, dm, state)
+(o::NADAM)(state, m, dm) = update(o, state, m, dm)
 
-function apply(o::NADAM, x, dx, state)
+function apply(o::NADAM, state, x, dx)
   η, β, ϵ = o.eta, o.beta, o.epsilon
 
   mt, vt, βt = state
@@ -454,9 +454,9 @@ AdaBelief(η = 1f-3, β = (9f-1, 9.99f-1), ϵ = eps(typeof(η))) = AdaBelief{typ
 
 init(o::AdaBelief, x::AbstractArray) = (zero(x), zero(x))
 
-(o::AdaBelief)(m, dm, state) = update(o, m, dm, state)
+(o::AdaBelief)(state, m, dm) = update(o, state, m, dm)
 
-function apply(o::AdaBelief, x, dx, state)
+function apply(o::AdaBelief, state, x, dx)
   η, β, ϵ = o.eta, o.beta, o.epsilon
   mt, st = state
 
@@ -482,9 +482,9 @@ WeightDecay() = WeightDecay(5f-4)
 
 init(o::WeightDecay, x::AbstractArray) = nothing
 
-(o::WeightDecay)(m, dm, state) = update(o, m, dm, state)
+(o::WeightDecay)(state, m, dm) = update(o, state, m, dm)
 
-function apply(o::WeightDecay, x, dx, state)
+function apply(o::WeightDecay, state, x, dx)
   dx = @. dx + o.wd * x
 
   return dx, state
@@ -503,12 +503,12 @@ OptimiserChain(opts...) = OptimiserChain(opts)
 
 init(o::OptimiserChain, x::AbstractArray) = [init(opt, x) for opt in o.opts]
 
-(o::OptimiserChain)(m, dm, state) = update(o, m, dm, state)
+(o::OptimiserChain)(state, m, dm) = update(o, state, m, dm)
 
-function apply(o::OptimiserChain, x, dx, states)
+function apply(o::OptimiserChain, states, x, dx)
   new_states = similar(states)
   for (i, (opt, state)) in enumerate(zip(o.opts, states))
-    dx, new_states[i] = apply(opt, x, dx, state)
+    dx, new_states[i] = apply(opt, state, x, dx)
   end
 
   return dx, new_states

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -503,7 +503,7 @@ OptimiserChain(opts...) = OptimiserChain(opts)
 
 init(o::OptimiserChain, x::AbstractArray) = [init(opt, x) for opt in o.opts]
 
-(o::OptimiserChain)(state, m, dm) = update(o, state, m, dm)
+(o::OptimiserChain)(state, m, dms...) = update(o, state, m, dms...)
 
 function apply(o::OptimiserChain, states, x, dx, dxs...)
   new_states = similar(states)

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -505,10 +505,10 @@ init(o::OptimiserChain, x::AbstractArray) = [init(opt, x) for opt in o.opts]
 
 (o::OptimiserChain)(state, m, dm) = update(o, state, m, dm)
 
-function apply(o::OptimiserChain, states, x, dx)
+function apply(o::OptimiserChain, states, x, dx, dxs...)
   new_states = similar(states)
   for (i, (opt, state)) in enumerate(zip(o.opts, states))
-    new_states[i], dx = apply(opt, state, x, dx)
+    new_states[i], dx = apply(opt, state, x, dx, dxs...)
   end
 
   return new_states, dx

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,7 +14,7 @@ using Statistics
     l = loss(w, w′)
     for i = 1:10^4
       gs = gradient(x -> loss(x, w′), w)
-      w, st = o(st, w, gs...)
+      st, w = o(st, w, gs...)
     end
     @test loss(w, w′) < 0.01
   end
@@ -30,7 +30,7 @@ end
   for t = 1:10^5
     x = rand(10)
     gs = gradient(w -> loss(x, w, w′), w)
-    w, st = Optimisers.update(opt, st, w, gs...)
+    st, w = Optimisers.update(opt, st, w, gs...)
   end
   @test loss(rand(10, 10), w, w′) < 0.01
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,7 +14,7 @@ using Statistics
     l = loss(w, w′)
     for i = 1:10^4
       gs = gradient(x -> loss(x, w′), w)
-      w, st = o(w, gs..., st)
+      w, st = o(st, w, gs...)
     end
     @test loss(w, w′) < 0.01
   end
@@ -30,7 +30,7 @@ end
   for t = 1:10^5
     x = rand(10)
     gs = gradient(w -> loss(x, w, w′), w)
-    w, st = Optimisers.update(opt, w, gs..., st)
+    w, st = Optimisers.update(opt, st, w, gs...)
   end
   @test loss(rand(10, 10), w, w′) < 0.01
 end


### PR DESCRIPTION
In response to [this discussion](https://github.com/FluxML/ML-Coordination-Tracker/discussions/22#discussioncomment-342967), this PR makes a simple change to the order of the arguments in our interface. Functionally, no changes are made.

Higher-order optimizers (e.g. AdaHessian) consume the first and second derivatives as arguments to the rule. This change allows us to support arbitrary number of derivative terms in the future (though it is limited to only the gradient for now).

Summary of changes:
- `apply(o, x, dx, st)` -> `apply(o, st, x, dx)`
- `update(o, x, dx, st)` -> `update(o, st, x, dx)`
- `o(x, dx, st)` -> `o(st, x, dx)`

The idea is that a future second-order rule would define `apply(o, st, x, grad, hessian) = ...`. And the `update` would be changed to support `Vararg`:
```julia
function update(o, state, x::T, x̄s...) where T
  if all(isnothing, x̄s)
    return x, state
  elseif isleaf(x)
    return _update(o, state, x, x̄s...)
  else
    # don't know if this is correct, but it's just a sketch
    x̄s = foreach(x̄ -> functor(typeof(x), x̄)[1], x̄s)
    x, restructure = functor(typeof(x), x)
    xstate = map((state, x, x̄s...) -> update(o, state, x, x̄s...), state, x, x̄s...)
    return restructure(map(first, xstate)), map(x -> x[2], xstate)
  end
end
```