### PR TITLE
Handle gradients and object trees together

### DIFF
--- a/src/Optimisers.jl
+++ b/src/Optimisers.jl
@@ -1,5 +1,6 @@
 module Optimisers
 
+using Functors
 using Functors: functor, fmap, isleaf
 
 include("interface.jl")

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -10,7 +10,7 @@ function state(o, x)
 end
 
 function _update(o, x, x̄, st)
-  st, x = apply(o, st, x, x̄)
+  x̄, st = apply(o, x, x̄, st)
   return patch(x, x̄), st
 end
 
@@ -36,4 +36,4 @@ _functor(T, x) = Functors.functor(T, x)
 init(o, x) = nothing
 
 # default all rules to first order calls
-apply(o, x, dx, dxs, state) = apply(o, x, dx, state)
+# apply(o, x, dx, dxs, state) = apply(o, x, dx, state)

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -9,9 +9,9 @@ function state(o, x)
   end
 end
 
-function _update(o, st, x, x̄)
-  st, x̄ = apply(o, st, x, x̄)
-  return st, patch(x, x̄)
+function _update(o, x, x̄, st)
+  st, x = apply(o, st, x, x̄)
+  return patch(x, x̄), st
 end
 
 function update(o, x::T, x̄, state) where T
@@ -36,4 +36,4 @@ _functor(T, x) = Functors.functor(T, x)
 init(o, x) = nothing
 
 # default all rules to first order calls
-apply(o, state, x, dx, dxs...) = apply(o, state, x, dx)
+apply(o, x, dx, dxs, state) = apply(o, x, dx, state)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,8 +13,8 @@ using Statistics
     loss(x, y) = mean((x.α .* x.β .- y.α .* y.β) .^ 2)
     l = loss(w, w′)
     for i = 1:10^4
-      gs = gradient(x -> loss(x, w′), w)
-      st, w = o(st, w, gs...)
+      gs, = gradient(x -> loss(x, w′), w)
+      w, st = o(w, gs, st)
     end
     @test loss(w, w′) < 0.01
   end
@@ -29,8 +29,8 @@ end
   st = Optimisers.state(opt, w)
   for t = 1:10^5
     x = rand(10)
-    gs = gradient(w -> loss(x, w, w′), w)
-    st, w = Optimisers.update(opt, st, w, gs...)
+    gs, = gradient(w -> loss(x, w, w′), w)
+    w, st = Optimisers.update(opt, w, gs, st)
   end
   @test loss(rand(10, 10), w, w′) < 0.01
 end


### PR DESCRIPTION
Flux has model structs, and Zygote would return NamedTuple gradients for them. With FluxML/Functors.jl#1 we add the ability to handle gradients in Functors.jl - in other words do a "zipped" tree walk on two equivalent functors and apply functions to them.

This extends the functionality to Optimisers.jl to allow for similar walks and apply `apply` (no pun intended). 

Further, it moves towards https://github.com/FluxML/Optimisers.jl/pull/16#issuecomment-897415899 for a nicer API

