### PR TITLE
Add `trainable`

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -35,6 +35,13 @@ Optimisers.update
 Optimisers.update!
 ```
 
+Calling `Functors.@functor` on your model's layer types by default causes the
+optimiser to act on all suitable fields. To restrict this, define `trainable`:
+
+```@docs
+Optimisers.trainable
+```
+
 ## Rule Definition
 
 ```@docs


### PR DESCRIPTION
Closes #35.

Should allow you to specify a NamedTuple with any subset of `children(x)`'s names, or a tuple like Flux uses. I hope that Flux could simply import this & things would work.

Otherwise minimal, does not make a `trainable_walk` or change too much else.