### PR TITLE
Handle tied weights in `update!`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 ChainRulesCore = "1"
-Functors = "0.2.8, 0.3"
+Functors = "0.3"
 Zygote = "0.6.40"
 julia = "1.6"
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -6,24 +6,23 @@ A new optimiser must overload two functions, [`apply!`](@ref) and [`init`](@ref)
 These act on one array of parameters:
 
 ```julia
-# Define a container to hold any optimiser specific parameters (if any):
+# Define a container to hold any optimiser specific parameters:
 struct DecayDescent{T} <: Optimisers.AbstractRule
-  η::T
+  eta::T
 end
 
-# Define an `apply!` rule which encodes how the gradients will be used to
-# update the parameters:
-function Optimisers.apply!(o::DecayDescent, state, x, x̄)
-  newx̄ = (o.η / √state) .* x̄
+# Define an `apply!` rule which encodes how the gradient will be adjusted:
+function Optimisers.apply!(o::DecayDescent, state, x, dx)
+  newdx = (o.eta / √state) .* dx
   nextstate = state + 1
-  return nextstate, newx̄
+  return nextstate, newdx
 end
 
 # Define the function which sets up the initial state (if any):
 Optimisers.init(o::DecayDescent, x::AbstractArray) = 1
 ```
 
-The parameters will be immediately updated to `x .- newx̄`, while `nextstate` is
+The parameters will be immediately updated to `x .- newdx`, while `nextstate` is
 caried to the next iteration.
 
 Notice that the state is handled separately from the optimiser itself. This

--- a/src/Optimisers.jl
+++ b/src/Optimisers.jl
@@ -2,6 +2,7 @@ module Optimisers
 
 using Functors: functor, fmap, isleaf
 using LinearAlgebra
+using Base: tail
 
 include("interface.jl")
 export AbstractRule

--- a/src/Optimisers.jl
+++ b/src/Optimisers.jl
@@ -1,6 +1,8 @@
 module Optimisers
 
 using Functors: functor, fmap, isleaf
+using ChainRulesCore: canonicalize, backing, Tangent, AbstractZero
+
 using LinearAlgebra
 using Base: tail
 
@@ -37,6 +39,11 @@ begin
   _conjugate(f::F, ::typeof(identity)) where F = f
   _conjugate(f::F, op::Union{typeof(transpose), typeof(adjoint)}) where F = (xs...,) -> op(f(op.(xs)...))
 end
+
+
+###
+### Docstrings for main interface
+###
 
 """
     Optimisers.apply!(rule::RuleType, state, parameters, gradient) -> (state, gradient)

--- a/src/Optimisers.jl
+++ b/src/Optimisers.jl
@@ -17,29 +17,6 @@ export Descent, Adam, Momentum, Nesterov, RMSProp,
        AdaGrad, AdaMax, AdaDelta, AMSGrad, NAdam, AdamW, RAdam, OAdam, AdaBelief,
        WeightDecay, ClipGrad, ClipNorm, OptimiserChain
 
-import Functors: functor
-# This is https://github.com/FluxML/Functors.jl/pull/33, put here just to simplify trying it out.
-begin
-  using LinearAlgebra
-  # The reason for these is to let W and W' be seen as tied weights in Flux models.
-  # Can't treat ReshapedArray very well, as its type doesn't include enough details for reconstruction.
-
-  functor(::Type{<:Adjoint}, x) = (parent = _adjoint(x),), y -> adjoint(only(y))
-
-  _adjoint(x) = adjoint(x)  # _adjoint is the inverse, and also understands more types:
-  _adjoint(x::NamedTuple{(:parent,)}) = x.parent  # "structural" gradient, and lazy broadcast used by Optimisers:
-  _adjoint(bc::Broadcast.Broadcasted{S}) where S = Broadcast.Broadcasted{S}(_conjugate(bc.f, adjoint), _adjoint.(bc.args))
-
-  functor(::Type{<:Transpose}, x) = (parent = _transpose(x),), y -> transpose(only(y))
-
-  _transpose(x) = transpose(x)
-  _transpose(x::NamedTuple{(:parent,)}) = x.parent
-  _transpose(bc::Broadcast.Broadcasted{S}) where S = Broadcast.Broadcasted{S}(_conjugate(bc.f, transpose), _transpose.(bc.args))
-
-  _conjugate(f::F, ::typeof(identity)) where F = f
-  _conjugate(f::F, op::Union{typeof(transpose), typeof(adjoint)}) where F = (xs...,) -> op(f(op.(xs)...))
-end
-
 
 ###
 ### Docstrings for main interface

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -17,7 +17,7 @@ function Base.show(io::IO, ℓ::Leaf)  # show method is mostly to hide its long 
   print(io, ")")
 end
 
-struct Tied; ties; tree; end
+struct Tied; ties; tree; end  # nothing about shared parameters is type-stable
 
 function setup(rule, x; ties = Pair[], cache = IdDict())
   rule isa AbstractRule || Base.depwarn("In future, all optimisation rules should be <: AbstractRule", :setup)
@@ -26,15 +26,12 @@ function setup(rule, x; ties = Pair[], cache = IdDict())
 end
 
 function _setup(rule, x, addr; ties, cache)
-  usecache = !isbits(x) && cache !== false
   if isnumeric(x)
-    if usecache && haskey(cache, x)
+    if haskey(cache, x)
       push!(ties, addr => cache[x])
       return nothing
     else
-      if usecache
-        cache[x] = addr
-      end
+      cache[x] = addr  # unlike the Functors cache, this one is only used for isnumeric objects
       return Leaf(rule, init(rule, x))
     end
   elseif isleaf(x)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -158,8 +158,8 @@ Optimisers.trainable(x::TwoThirds) = (a = x.a,)
 
     @testset "tied weights" begin
       @testset "tuples" begin
-        twice = [1,2]
-        mtup = (twice, ([3,4], twice))
+        twice = [1,2.0]
+        mtup = (twice, ([3,4.0], twice))
 
         stup = Optimisers.setup(Descent(0.1), mtup)
         @test stup isa Optimisers.Tied
@@ -190,8 +190,8 @@ Optimisers.trainable(x::TwoThirds) = (a = x.a,)
         @test mt4[1] ≈ [1,2] - 0.1 * [7,7]
       end
       @testset "named" begin
-        thrice = [3]
-        model = (a = (x = thrice, y = [4,5,6], z = true), b = ((m = (0, 1, thrice),),), c = (x = [7,8], y = thrice))
+        thrice = [3f0]
+        model = (a = (x = thrice, y = Float32[4,5,6], z = true), b = ((m = (0, 1, thrice),),), c = (x = Float32[7,8], y = thrice))
         tree = Optimisers.setup(Momentum(0.1, 0.9), model)
         tree.ties
         @test model.a.x === model.b[1].m[3] == model.c.y

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -162,7 +162,7 @@ Optimisers.trainable(x::TwoThirds) = (a = x.a,)
         mtup = (twice, ([3,4], twice))
 
         stup = Optimisers.setup(Descent(0.1), mtup)
-        @test stup isa Optimisers.Tree
+        @test stup isa Optimisers.Tied
         @test stup.ties[1] == Pair((2, 2), (1,))
         gtup = ([3,3], ([5,5], [7,7]))
 
@@ -177,7 +177,7 @@ Optimisers.trainable(x::TwoThirds) = (a = x.a,)
         @test Optimisers.place(_ -> [10, 10], mtup, ([3,3], nothing), (2, 3)) == ([3, 3], (nothing, nothing))  # invalid index
 
         snew, mnew = Optimisers.update(stup, mtup, gtup)
-        @test snew isa Optimisers.Tree
+        @test snew isa Optimisers.Tied
         @test snew.ties[1] == stup.ties[1]
         @test mnew[1] ≈ [1,2] - 0.1 * ([3,3] + [7,7])  # gradient was accumulated
         @test mnew[2][2] === mnew[1]  # and tie is not broken


### PR DESCRIPTION
This alters `setup` to record the "address" of any tied weights, and then `update!` to first add the gradient of the second to the first (of each pair), then update as normal, and finally re-create the tie in the updated model.

I've tried to match the existing `update!` as much as possible. The format in which the "address" is stored is just a tuple of property names. The function to "pick out" a gradient component based on this is easy. The one to "place back" the modified one is trickier, as it needs to re-create missing branches -- and not just the minimal branch, but all the other empty fields. So it walks the model in parallel to the gradient, a lot like the existing `update!`. This isn't something that e.g. Setfield.jl thinks about.

Maybe this could all be abstracted away somehow, moved up into Functors? We seem to need quite a few patterns which aren't like `fmap`.

Surely the "address" could be stored in a more compile-away-able format, alla Setfield.jl. None of this is type stable, and it takes a few μs. I think that's true of everything in Functors.jl too. And it might even be desirable, for startup speed with deeply nested models. 

~~This is on top of #41.~~ Uses https://github.com/FluxML/Functors.jl/pull/33, which is copied in here for now.