### PR TITLE
Stop testing on windows + mac

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,6 @@ jobs:
           - 'nightly'
         os:
           - ubuntu-latest
-          - macOS-latest
-          - windows-latest
         arch:
           - x64
     steps:


### PR DESCRIPTION
I don't think anything here is OS dependent. And 10 tests means they get stuck behind each other in the queue.