### PR TITLE
Separate `@lazy` from `@..` macro, fix some bugs

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -48,4 +48,5 @@ Optimisers.trainable
 Optimisers.apply!
 Optimisers.init
 Optimisers.@..
+Optimisers.@lazy
 ```

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -111,6 +111,9 @@ Broadcast.broadcasted(::typeof(lazy), x) = Lazy(x)
 struct Lazy{T}; bc::T; end
 Broadcast.materialize(x::Lazy) = Broadcast.instantiate(x.bc)
 
+constantlike(λ::T, x::AbstractArray{T}) where T = map(_ -> λ, x)
+constantlike(λ, x::AbstractArray{T}) where T = constantlike(convert(float(T), λ), x)
+
 function Base.show(io::IO, ℓ::Leaf)  # show method is mostly to hide its long type!
   ioc = IOContext(io, :compact => true)
   print(ioc, "Leaf(", ℓ.rule, ", ")

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -78,29 +78,32 @@ end
 
 """
     @.. x = x + y
-    @.. x + y / z
 
-Magic broadcasting macro, for use in `apply!` rules:
-* Applied to assignment `x = rhs` it is like `@.` unless `!iswriteable(x)`,
-  in which case it becomes `x = @. rhs`. Does not check the eltype before writing.
-  Does not know about `x += rhs` etc.
-* Applied to other expressions, it broadcasts like `@.` but does not materialise,
-  returning a `Broadcasted` object for later use. Beware that mutation of arguments
-  will affect the result, and that if it is used in two places work will be done twice.
+Sometimes in-place broadcasting macro, for use in `apply!` rules.
+If `iswriteable(x)` then it is just `@. x = rhs`, but if not, it becomes `x = @. rhs`.
 """
 macro var".."(ex)
-  if Meta.isexpr(ex, :(=))
-    dst = esc(ex.args[1])
-    src = esc(Broadcast.__dot__(ex.args[2]))
-    :($dst = if $iswriteable($dst)
-        $dst .= $src
-      else
-        $src
-      end)
-  else
-    bc = esc(Broadcast.__dot__(ex))
-    :($lazy.($bc))
-  end
+  Meta.isexpr(ex, :(=)) || throw("the macro @.. only accepts assignment, like @.. x = y + z")
+  dst = esc(ex.args[1])
+  src = esc(Broadcast.__dot__(ex.args[2]))
+  :($dst = if $iswriteable($dst)
+      $dst .= $src
+    else
+      $src
+    end)
+end
+
+"""
+    x = @lazy y + z
+
+Lazy broadcasting macro, for use in `apply!` rules. It broadcasts like `@.`
+but does not materialise, returning a `Broadcasted` object for later use.
+Beware that mutation of arguments will affect the result,
+and that if it is used in two places, work will be done twice.
+"""
+macro lazy(ex)
+  bc = esc(Broadcast.__dot__(ex))
+  :($lazy.($bc))
 end
 
 function lazy end

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -111,8 +111,8 @@ Broadcast.broadcasted(::typeof(lazy), x) = Lazy(x)
 struct Lazy{T}; bc::T; end
 Broadcast.materialize(x::Lazy) = Broadcast.instantiate(x.bc)
 
-constantlike(λ::T, x::AbstractArray{T}) where T = map(_ -> λ, x)
-constantlike(λ, x::AbstractArray{T}) where T = constantlike(convert(float(T), λ), x)
+onevalue(λ::T, x::AbstractArray{T}) where T = map(_ -> λ, x)
+onevalue(λ, x::AbstractArray{T}) where T = onevalue(convert(float(T), λ), x)
 
 function Base.show(io::IO, ℓ::Leaf)  # show method is mostly to hide its long type!
   ioc = IOContext(io, :compact => true)

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -81,8 +81,8 @@ end
     @.. x + y / z
 
 Magic broadcasting macro, for use in `apply!` rules:
-* Applied to assignment `x = ...` it is like `@.` unless `!iswriteable(x)`,
-  in which case it ignores `x`, and applies `@.` on the right.
+* Applied to assignment `x = rhs` it is like `@.` unless `!iswriteable(x)`,
+  in which case it becomes `x = @. rhs`.
 * Applied to other expressions, it broadcasts like `@.` but does not materialise,
   returning a `Broadcasted` object for later use.
 """
@@ -90,7 +90,7 @@ macro var".."(ex)
   if Meta.isexpr(ex, :(=))
     dst = esc(ex.args[1])
     src = esc(Broadcast.__dot__(ex.args[2]))
-    :(if $iswriteable($dst)
+    :($dst = if $iswriteable($dst)
         $dst .= $src
       else
         $src

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -82,9 +82,11 @@ end
 
 Magic broadcasting macro, for use in `apply!` rules:
 * Applied to assignment `x = rhs` it is like `@.` unless `!iswriteable(x)`,
-  in which case it becomes `x = @. rhs`.
+  in which case it becomes `x = @. rhs`. Does not check the eltype before writing.
+  Does not know about `x += rhs` etc.
 * Applied to other expressions, it broadcasts like `@.` but does not materialise,
-  returning a `Broadcasted` object for later use.
+  returning a `Broadcasted` object for later use. Beware that mutation of arguments
+  will affect the result, and that if it is used in two places work will be done twice.
 """
 macro var".."(ex)
   if Meta.isexpr(ex, :(=))

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -270,7 +270,7 @@ struct ADAGrad{T}
 end
 ADAGrad(η = 1f-1, ϵ = eps(typeof(η))) = ADAGrad{typeof(η)}(η, ϵ)
 
-init(o::ADAGrad, x::AbstractArray) = fill!(similar(x), o.epsilon)
+init(o::ADAGrad, x::AbstractArray) = map(_ -> o.epsilon, x)
 
 function apply!(o::ADAGrad, state, x, dx)
   η, ϵ = o.eta, o.epsilon
@@ -337,7 +337,7 @@ end
 AMSGrad(η = 1f-3, β = (9f-1, 9.99f-1), ϵ = eps(typeof(η))) = AMSGrad{typeof(η)}(η, β, ϵ)
 
 init(o::AMSGrad, x::AbstractArray) =
-  (fill!(similar(x), o.epsilon), fill!(similar(x), o.epsilon), fill!(similar(x), o.epsilon))
+  (map(_ -> o.epsilon, x), map(_ -> o.epsilon, x), map(_ -> o.epsilon, x))
 
 function apply!(o::AMSGrad, state, x, dx)
   η, β, ϵ = o.eta, o.beta, o.epsilon

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -246,7 +246,7 @@ function apply!(o::OADAM, state, x, dx)
   @.. vt = β[2] * vt + (1 - β[2]) * dx^2
   prev = copy(term)
   @.. term = η * mt / (1 - βt[1]) / (sqrt(vt / (1 - βt[2])) + ϵ)
-  dx′ = @. 2 * term - prev
+  dx′ = @.. 2 * term - prev
 
   return (mt, vt, βt .* β, term), dx′
 end

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -69,10 +69,10 @@ init(o::Nesterov, x::AbstractArray) = zero(x)
 function apply!(o::Nesterov, state, x, dx)
   η, ρ, vel = o.eta, o.rho, state
 
-  md = @. - ρ^2 * vel + (1+ρ) * η * dx  # Cannot be lazy as this needs the old velocity
+  newdx = @. - ρ^2 * vel + (1+ρ) * η * dx  # Cannot be lazy as this needs the old velocity
   @.. vel = ρ * vel - η * dx
   
-  return vel, md
+  return vel, newdx
 end
 
 """

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -271,7 +271,7 @@ struct ADAGrad{T}
 end
 ADAGrad(η = 1f-1, ϵ = eps(typeof(η))) = ADAGrad{typeof(η)}(η, ϵ)
 
-init(o::ADAGrad, x::AbstractArray) = constantlike(o.epsilon, x)
+init(o::ADAGrad, x::AbstractArray) = onevalue(o.epsilon, x)
 
 function apply!(o::ADAGrad, state, x, dx)
   η, ϵ = o.eta, o.epsilon
@@ -337,7 +337,7 @@ end
 AMSGrad(η = 1f-3, β = (9f-1, 9.99f-1), ϵ = eps(typeof(η))) = AMSGrad{typeof(η)}(η, β, ϵ)
 
 init(o::AMSGrad, x::AbstractArray) =
-  (constantlike(o.epsilon, x), constantlike(o.epsilon, x), constantlike(o.epsilon, x))
+  (onevalue(o.epsilon, x), onevalue(o.epsilon, x), onevalue(o.epsilon, x))
 
 function apply!(o::AMSGrad, state, x, dx)
   η, β, ϵ = o.eta, o.beta, o.epsilon

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -240,17 +240,15 @@ init(o::OADAM, x::AbstractArray) = (zero(x), zero(x), o.beta, zero(x))
 
 function apply!(o::OADAM, state, x, dx)
   η, β, ϵ = o.eta, o.beta, o.epsilon
-
-  mt, vt, βt, dxterm = state
+  mt, vt, βt, term = state
 
   @.. mt = β[1] * mt + (1 - β[1]) * dx
   @.. vt = β[2] * vt + (1 - β[2]) * dx^2
+  prev = copy(term)
+  @.. term = η * mt / (1 - βt[1]) / (sqrt(vt / (1 - βt[2])) + ϵ)
+  dx′ = @. 2 * term - prev
 
-  # This dx broadcast is not lazy, because dxterm might get mutated:
-  dx′ = @. 2 * η * mt / (1 - βt[1]) / (sqrt(vt / (1 - βt[2])) + ϵ) - dxterm
-  @.. dxterm = η * mt / (1 - βt[1]) / (sqrt(vt / (1 - βt[2])) + ϵ)
-
-  return (mt, vt, βt .* β, dxterm), dx′
+  return (mt, vt, βt .* β, term), dx′
 end
 
 """

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -41,10 +41,10 @@ Momentum(η = 1f-2, ρ = 9f-1) = Momentum{typeof(η)}(η, ρ)
 init(o::Momentum, x::AbstractArray) = zero(x)
 
 function apply!(o::Momentum, state, x, dx)
-  η, ρ, mv = o.eta, o.rho, state
-  @.. mv = - ρ * mv + η * dx  # Macro @.. broadcasts into v if it can, else @. of rhs.
+  η, ρ, mvel = o.eta, o.rho, state
+  @.. mvel = ρ * mvel + η * dx  # Macro @.. broadcasts into mvel if it can, else @. of rhs.
   
-  return mv, mv
+  return mvel, mvel
 end
 
 """
@@ -67,12 +67,12 @@ Nesterov(η = 1f-3, ρ = 9f-1) = Nesterov{typeof(η)}(η, ρ)
 init(o::Nesterov, x::AbstractArray) = zero(x)
 
 function apply!(o::Nesterov, state, x, dx)
-  η, ρ, v = o.eta, o.rho, state
+  η, ρ, vel = o.eta, o.rho, state
 
-  d = @. - ρ^2 * v + (1+ρ) * η * dx  # Cannot be lazy as this needs the old v
-  @.. v = ρ * v - η * dx
+  md = @. - ρ^2 * vel + (1+ρ) * η * dx  # Cannot be lazy as this needs the old velocity
+  @.. vel = ρ * vel - η * dx
   
-  return v, d
+  return vel, md
 end
 
 """
@@ -403,7 +403,7 @@ weight decay regularization.
                          (no need to change default)
 """
 ADAMW(η = 1f-3, β = (9f-1, 9.99f-1), γ = 0, ϵ = eps(typeof(η))) =
-  OptimiserChain(ADAM{typeof(η)}(η, β, ϵ), WeightDecay(γ))
+  OptimiserChain(ADAM{typeof(η)}(η, β, ϵ), WeightDecay{typeof(η)}(γ))
 
 """
     AdaBelief(η = 1f-3, β = (9f-1, 9.99f-1), ϵ = eps(typeof(η)))

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -131,7 +131,7 @@ ADAM(η = 1f-3, β = (9f-1, 9.99f-1), ϵ = eps(typeof(η))) = ADAM{typeof(η)}(�
 
 init(o::ADAM, x::AbstractArray) = (zero(x), zero(x), o.beta)
 
-function apply!(o::ADAM{T}, state, x, dx) where T
+function apply!(o::ADAM, state, x, dx)
   η, β, ϵ = o.eta, o.beta, o.epsilon
   mt, vt, βt = state
 
@@ -271,7 +271,7 @@ struct ADAGrad{T}
 end
 ADAGrad(η = 1f-1, ϵ = eps(typeof(η))) = ADAGrad{typeof(η)}(η, ϵ)
 
-init(o::ADAGrad, x::AbstractArray) = map(_ -> o.epsilon, x)
+init(o::ADAGrad, x::AbstractArray) = constantlike(o.epsilon, x)
 
 function apply!(o::ADAGrad, state, x, dx)
   η, ϵ = o.eta, o.epsilon
@@ -337,7 +337,7 @@ end
 AMSGrad(η = 1f-3, β = (9f-1, 9.99f-1), ϵ = eps(typeof(η))) = AMSGrad{typeof(η)}(η, β, ϵ)
 
 init(o::AMSGrad, x::AbstractArray) =
-  (map(_ -> o.epsilon, x), map(_ -> o.epsilon, x), map(_ -> o.epsilon, x))
+  (constantlike(o.epsilon, x), constantlike(o.epsilon, x), constantlike(o.epsilon, x))
 
 function apply!(o::AMSGrad, state, x, dx)
   η, β, ϵ = o.eta, o.beta, o.epsilon

--- a/test/rules.jl
+++ b/test/rules.jl
@@ -137,7 +137,7 @@ end
     @test xfill.a != ones(2,2)
     @test xfill.b != ones(2,2)
 
-    bc = Optimisers.@.. 1 + log([2 3; 4 5]) / 6
+    bc = Optimisers.@lazy 1 + log([2 3; 4 5]) / 6
     _, xbc = Optimisers.update(s, x, (a = bc, b = bc))
     @test xbc.a != ones(2,2)
     @test xbc.b != ones(2,2)

--- a/test/rules.jl
+++ b/test/rules.jl
@@ -63,13 +63,7 @@ end
       gs = gradient(x -> loss(x, w′), w)
       st, w = Optimisers.update(st, w, gs...)
     end
-    lw = loss(w, w′)
-    if o isa ADADelta
-      @show name(o) loss(w, w′)
-      @test_broken lw < 0.001
-    else
-      @test lw < 0.001
-    end
+    @test loss(w, w′) < 0.001
   end
 end
 
@@ -90,7 +84,7 @@ end
       g = gradient(m -> s_loss(m, x, y), model)[1]
       state, model = Optimisers.update!(state, model, g)
     end
-    if o isa Union{Descent, RMSProp, ADAGrad, ADADelta, NADAM}
+    if o isa Descent
       @show name(o) s_loss(model, x, y)
       @test_broken s_loss(model, x, y) < 1
     else

--- a/test/rules.jl
+++ b/test/rules.jl
@@ -149,3 +149,20 @@ end
   end
 end
 
+@testset verbose=true "mutation check" begin
+  # If @lazy captures a matrix which is later mutated, the results won't agree here:
+  @testset "$(name(o))" for o in RULES
+    model = Float64.(rand(Int8, 8))
+    s_model = SVector{8}(model)
+    grads = [Float64.(rand(Int8, 8)) for t in 1:13]
+    s_grads = [SVector{8}(x) for x in grads]
+    state = Optimisers.setup(o, model)
+    s_state = Optimisers.setup(o, s_model)
+    for t in 1:13
+      state, model = Optimisers.update!(state, model, grads[t])
+      s_state, s_model = Optimisers.update!(s_state, s_model, s_grads[t])
+    end
+    @test model == s_model
+  end
+end
+

--- a/test/rules.jl
+++ b/test/rules.jl
@@ -5,7 +5,7 @@ using LinearAlgebra, Statistics, Test, Random
 Random.seed!(1)
 
 RULES = [
-  # All the rules at default settings
+  # All the rules at default settings:
   Descent(), ADAM(), Momentum(), Nesterov(), RMSProp(),
   ADAGrad(), AdaMax(), ADADelta(), AMSGrad(), NADAM(),
   ADAMW(), RADAM(), OADAM(), AdaBelief(),
@@ -13,6 +13,7 @@ RULES = [
   OptimiserChain(WeightDecay(), ADAM(0.001)),
   OptimiserChain(ClipNorm(), ADAM(0.001)),
   OptimiserChain(ClipGrad(0.5), Momentum()),
+  OptimiserChain(WeightDecay(), OADAM(), ClipGrad(1)),
 ]
 
 name(o) = typeof(o).name.name
@@ -112,7 +113,7 @@ end
     end
     @test upstatic[1] isa SVector
 
-    # With ordinary Array gradient, what happens?
+    # With ordinary Array gradient, what happens? Not so important!
     upstatic2 = Optimisers.update(Optimisers.setup(o, mstatic), mstatic, marray[1:2])[2]
     # @test map(eltype, upstatic2) == types[1:2]  # same information
     if upstatic2[1] isa SVector

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -127,6 +127,8 @@ Optimisers.trainable(x::TwoThirds) = (a = x.a,)
       r = 1.0:2.0  # immutable
       @test (@.. r = y * z) isa Array
       @test (@.. r = y * z) == y .* z
+      @.. r = y * z
+      @test r == y .* z  # attaches name r to result
     end
 
     @testset "tied weights" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
 using Optimisers
 using ChainRulesCore, Functors, StaticArrays, Zygote
 using LinearAlgebra, Statistics, Test, Random
-using Optimisers: @..
+using Optimisers: @.., @lazy
 
 Random.seed!(1)
 
@@ -116,10 +116,10 @@ Optimisers.trainable(x::TwoThirds) = (a = x.a,)
       @test Optimisers.update!(s, m, g...)[2] isa Foo
     end
 
-    @testset "broadcasting macro" begin
+    @testset "broadcasting macros" begin
       x = [1.0, 2.0]; y = [3,4]; z = [5,6]
-      @test (@.. x + y * z) isa Broadcast.Broadcasted
-      bc = @.. x + y * z
+      @test (@lazy x + y * z) isa Broadcast.Broadcasted
+      bc = @lazy x + y * z
       @test (y .+ 2 .* bc) == [35,56]
 
       @test (@.. x = y * z) isa Array


### PR DESCRIPTION
This changes the behaviour of `@.. x = rhs` on immutable objects, to attach the label to the new result. While this may mean that the type of `x` changes, it also fixes several bugs where later lines assumed that `x` would be the new one. Should have noticed this on the first pass, sorry. (This was added in #31.)

There are more subtle ways for things to go wrong. Flux's implementation of OADAM uses the mutable gradient array as the place to save an intermediate step: 
https://github.com/FluxML/Flux.jl/blob/05a608b3fb540661bf68c339793cd7083e2ad400/src/optimise/optimisers.jl#L311-L326
That won't work if `Δ == dx` is immutable, but attaching the label to the RHS also won't work, if that gets mutated in the next step. And in general mutating the gradient is unsafe, if could also be someone else's gradient. ~~So for now I make it explicitly materialise the new `dx`, and then update the saved term. Broadcasting a `sqrt` is not super-expensive.~~ Changed now to an explicit copy of `term`, before updating.

<img width="774" alt="Screenshot 2022-01-30 at 13 56 53" src="https://user-images.githubusercontent.com/32575566/151713454-688ecb11-d3b1-4217-bd20-e4fae80d6dfc.png">


In fact, the whole lazy-Broadcasted idea assumes that the function being broadcasted isn't expensive. E.g. `ADADelta` doesn't have correctness bugs, but will compute the sqrt etc. when doing `Δacc =`, and again when `dx′` is ultimately consumed in `subtract!`. 