### PR TITLE
Per-leaf freezing

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -33,6 +33,8 @@ Optimisers.OptimiserChain
 Optimisers.setup
 Optimisers.update
 Optimisers.update!
+Optimisers.freeze
+Optimisers.thaw
 ```
 
 Calling `Functors.@functor` on your model's layer types by default causes the

--- a/src/Optimisers.jl
+++ b/src/Optimisers.jl
@@ -104,4 +104,25 @@ arrays within the old model (and the old state), it will be faster for models of
 """
 update!
 
+"""
+    Optimisers.freeze(tree, branches) -> tree
+
+Disable training of part of the model, by modifying the optimiser states
+returned by [`setup`](@ref). Which branches to alter is specified by:
+* a symbol `:encoder` to shield all nodes within `model.encoder` from `update`,
+* a tuple `(:layers, 1, :enc, 3)` to fix all nodes within `model.layers[1].enc[3]`, and
+* a vector `[:enc, (:dec, 2), (:dec, 3)]` to act on all the given parts.
+
+The reverse is [`thaw`](@ref), which by default acts on all nodes.
+"""
+freeze
+
+"""
+    Optimisers.thaw(tree, branches = ()) -> tree
+
+Removes the restrictions placed by [`freeze`](@ref). By default walks over the complete
+tree of optimisers states, but can also be applied to only some branches.
+"""
+thaw
+
 end # module

--- a/src/Optimisers.jl
+++ b/src/Optimisers.jl
@@ -2,6 +2,7 @@ module Optimisers
 
 using Functors: functor, fmap, isleaf
 using LinearAlgebra
+using Base: tail
 
 include("interface.jl")
 include("rules.jl")


### PR DESCRIPTION
This is one way we could handle freezing of certain nodes, by altering the state tree.

```julia
julia> model = (x=[1,2], y=([3,4], sin));

julia> state = Optimisers.setup(Descent(), model);

julia> state = Optimisers.freeze(state, :y)
(x = Leaf(Descent{Float32}(0.1), nothing, false), y = (Leaf(Descent{Float32}(0.1), nothing, true), nothing))

julia> state, model = Optimisers.update(state, model, (x=[1,10], y=([100,1000], nothing)));

julia> model
(x = [0.8999999985098839, 0.9999999850988388], y = ([3, 4], sin))

julia> state = Optimisers.thaw(state)
(x = Leaf(Descent{Float32}(0.1), nothing, false), y = (Leaf(Descent{Float32}(0.1), nothing, false), nothing))

julia> state, model = Optimisers.update(state, model, (x=[1,10], y=([100,1000], nothing)));

julia> model
(x = [0.7999999970197678, -2.9802322387695312e-8], y = ([-7.000000149011612, -96.00000149011612], sin))
```