### PR TITLE
Explicitly preserve eltype

### DIFF
--- a/src/Optimisers.jl
+++ b/src/Optimisers.jl
@@ -24,11 +24,11 @@ The initial state is `init(rule::RuleType, parameters)`.
 
 # Example
 ```jldoctest
-julia> Optimisers.init(Descent(0.1), [1,2,3]) === nothing
+julia> Optimisers.init(Descent(0.1), Float32[1,2,3]) === nothing
 true
 
-julia> Optimisers.apply!(Descent(0.1), nothing, [1,2,3], [4,5,6])
-(nothing, Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}}(*, ([4, 5, 6], 0.1)))
+julia> Optimisers.apply!(Descent(0.1), nothing, Float32[1,2,3], [4,5,6])
+(nothing, Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}}(*, ([4, 5, 6], 0.1f0)))
 ```
 """
 apply!
@@ -41,7 +41,7 @@ This and [`apply!`](@ref) are the two functions which any new optimisation rule 
 
 # Examples
 ```jldoctest
-julia> Optimisers.init(Descent(), [1,2,3])  # is `nothing`
+julia> Optimisers.init(Descent(), Float32[1,2,3])  # is `nothing`
 
 julia> Optimisers.init(Momentum(), [1.0, 2.0])
 2-element Vector{Float64}:

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -21,7 +21,7 @@ function setup(rule, x; seen = Base.IdSet())
   end
 end
 
-subtract!(x, x̄) = iswriteable(x) ? (x .= x .- x̄) : (x .- x̄)
+subtract!(x, x̄) = iswriteable(x) ? (x .= x .- x̄) : eltype(x).(x .- x̄)
 
 update!(::Nothing, x, ::Zero, ::Zero...) = nothing, x
 update!(::Nothing, x, x̄s...) = nothing, x
@@ -50,10 +50,10 @@ end
 apply!(o, state, x, dx, dxs...) = apply!(o, state, x, dx)
 
 isnumeric(x::AbstractArray{<:Number}) = isleaf(x)  # isleaf to allow for e.g. transposed shared weights
-isnumeric(x::AbstractArray{<:Bool}) = false  # convention of ChainRules is that Bool is non-differentiable
+isnumeric(x::AbstractArray{<:Integer}) = false
 isnumeric(x) = false
 
-iswriteable(::DenseArray{<:AbstractFloat}) = true  # more elaborate versions are possible, wait until needed?
+iswriteable(::DenseArray) = true  # more elaborate versions are possible, wait until needed?
 iswriteable(_) = false
 
 """

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -525,7 +525,7 @@ This is equivalent to `Descent(1)`.
 ```jldoctest
 julia> o = OptimiserChain(ClipGrad(1), Descent(0.1));
 
-julia> m = ([0,0,0],);
+julia> m = (zeros(3),);
 
 julia> s = Optimisers.setup(o, m)
 (Leaf(OptimiserChain(ClipGrad{Int64}(1), Descent{Float64}(0.1)), [nothing, nothing]),)

--- a/test/rules.jl
+++ b/test/rules.jl
@@ -118,11 +118,7 @@ end
     # Static version is truly out-of-place:
     mstatic = (SA{Float32}[1,2], SA{Float64}[3,4]) # , SA{Float16}[5,6])  with Float16, all fail
     upstatic = Optimisers.update(Optimisers.setup(o, mstatic), mstatic, mstatic)[2]
-    if o isa OptimiserChain && o.opts[2] isa ADAM  # These promote to Float64
-      @test_broken map(eltype, upstatic) == types[1:2]
-    else
-      @test map(eltype, upstatic) == types[1:2]
-    end
+    @test map(eltype, upstatic) == types[1:2]
     @test upstatic[1] isa SVector
 
     # With ordinary Array gradient, what happens? Not so important!


### PR DESCRIPTION
Closes #55

This now rejects arrays of integers as not being things to optimise. Previously, they were, but most optimisers will promote to a float, and `update!` then didn't write in-place, and returned arrays of floats on the first run. I start to think it's cleaner just to declare that `Vector{Int}` cannot be trained.