### PR TITLE
Add `total(f, model)` to replace implicit `sum(f, Flux.params(model))`

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -52,11 +52,13 @@ Optimisers.trainable
 Optimisers.isnumeric
 ```
 
-Such restrictions are also obeyed by this function for flattening a model:
+Such restrictions are also obeyed by this function for flattening a model,
+and one for applying a function to every parameter:
 
 ```@docs
 Optimisers.destructure
 Optimisers.Restructure
+Optimisers.total
 ```
 
 ## Rule Definition

--- a/src/Optimisers.jl
+++ b/src/Optimisers.jl
@@ -9,7 +9,7 @@ export AbstractRule
 include("adjust.jl")
 
 include("destructure.jl")
-export destructure
+export destructure, total
 
 include("rules.jl")
 export Descent, Adam, Momentum, Nesterov, Rprop, RMSProp,


### PR DESCRIPTION
This proposes to add some kind of differentiable `sum(f, trainable(x))` which walks the model. I'm not certain this is the right thing yet. 

Right now this gets all trainable parameters. But perhaps a variant which takes a type `total(f, Union{Dense, Conv}, model)` might be a better explicit-parameters replacement for `modules`? Xref  https://github.com/FluxML/Flux.jl/pull/1863#discussion_r800084248

Closes https://github.com/FluxML/Functors.jl/issues/35 , probably.

Edit: since I couldn't find this, big Flux issue about explicit parameters is https://github.com/FluxML/Flux.jl/issues/1986 and snippet with a quick way to write `total` here: https://github.com/FluxML/Flux.jl/issues/2040#issuecomment-1535535892