### PR TITLE
Allow zero-arrays

### DIFF
--- a/src/Optimisers.jl
+++ b/src/Optimisers.jl
@@ -2,6 +2,7 @@ module Optimisers
 
 using Functors: functor, fmap, isleaf
 using LinearAlgebra
+using Base.Broadcast: broadcast_preserving_zero_d, broadcasted
 
 include("interface.jl")
 

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -21,7 +21,13 @@ function setup(rule, x; seen = Base.IdSet())
   end
 end
 
-subtract!(x, x̄) = iswriteable(x) ? (x .= x .- x̄) : eltype(x).(x .- x̄)
+function subtract!(x, x̄)
+  if iswriteable(x)
+    x .= x .- x̄
+  else
+    broadcast_preserving_zero_d(eltype(x), broadcasted(-, x, x̄))
+  end
+end
 
 update!(::Nothing, x, ::Zero, ::Zero...) = nothing, x
 update!(::Nothing, x, x̄s...) = nothing, x

--- a/test/rules.jl
+++ b/test/rules.jl
@@ -251,6 +251,6 @@ end
       @test sum(m.arr) < 0.3
       @test sum(m.pda) < 0.3
     end
-    @test_broken only(m.ref) < 0.3  # not currently regarded as trainable
+    @test only(m.ref) ≈ 1  # not currently regarded as trainable
   end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -152,7 +152,7 @@ Optimisers.trainable(x::TwoThirds) = (a = x.a,)
       s5 = Optimisers.setup(Descent(0.1), m5)
       g5 = gradient(m -> m[]^2, m5)[1]  # (x = 2.0,)
       s6, m6 = Optimisers.update!(s5, m5, g5)
-      @test_broken m6[] ≈ 0.8
+      @test m6[] ≈ 1
     end
 
     @testset "forgotten gradient" begin


### PR DESCRIPTION
This wants to check that zero-dimensional arrays are allowed, and preserved. 

But they aren't right now, because `subtract!` will return a number. Unless it's writing in-place. Unless we use `broadcast_preserving_zero_d`, which, edit, this PR now does:
```julia
julia> m = (a = fill(1.0), b = SArray{Tuple{}}(fill(1.0)), c = PermutedDimsArray(fill(1.0), ()));

# normal arrays

julia> m.a .- m.a
0.0

julia> Broadcast.broadcast_preserving_zero_d(-, m.a, m.a)
0-dimensional Array{Float64, 0}:
0.0
```
This doesn't work for StaticArrays, maybe that's their problem not ours:
```
julia> m.b .- m.b
Scalar{Float64}((0.0,))

julia> Broadcast.broadcast_preserving_zero_d(-, m.b, m.b)
ERROR: MethodError: no method matching similar(::Base.Broadcast.Broadcasted{StaticArrays.StaticArrayStyle{0}, Nothing, typeof(-), Tuple{Scalar{Float64}, Scalar{Float64}}}, ::Type{Scalar{Float64}}, ::Tuple{})
Closest candidates are:
  similar(::Union{Adjoint{T, S}, Transpose{T, S}} where {T, S}, ::Type{T}, ::Tuple{Vararg{Int64, N}}) where {T, N} at ~/.julia/dev/julia/usr/share/julia/stdlib/v1.8/LinearAlgebra/src/adjtrans.jl:212
  similar(::Base.ReinterpretArray, ::Type, ::Tuple{Vararg{Int64, N}} where N) at ~/.julia/dev/julia/usr/share/julia/base/reinterpretarray.jl:185
  similar(::UpperHessenberg, ::Type{T}, ::Tuple{Vararg{Int64, N}}) where {T, N} at ~/.julia/dev/julia/usr/share/julia/stdlib/v1.8/LinearAlgebra/src/hessenberg.jl:61
  ...
Stacktrace:
 [1] similar(bc::Base.Broadcast.Broadcasted{StaticArrays.StaticArrayStyle{0}, Nothing, typeof(-), Tuple{Scalar{Float64}, Scalar{Float64}}}, #unused#::Type{Scalar{Float64}})
   @ Base.Broadcast ./broadcast.jl:211
```
~~Alternatively, we could ban zero-arrays as being too weird.~~