### PR TITLE
Missing `vec` in gradient of `destructure`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Optimisers"
 uuid = "3bd65402-5787-11e9-1adc-39752487f4e2"
 authors = ["Mike J Innes <mike.j.innes@gmail.com>"]
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/destructure.jl
+++ b/src/destructure.jl
@@ -131,7 +131,7 @@ function _grad!(x, dx, off, flat::AbstractVector)
   flat
 end
 function _grad!(x, dx, off::Integer, flat::AbstractVector)
-  @views flat[off .+ (1:length(x))] .+= dx  # must visit all tied nodes
+  @views flat[off .+ (1:length(x))] .+= vec(dx)  # must visit all tied nodes
   flat
 end
 _grad!(x, dx::Zero, off, flat::AbstractVector) = dx


### PR DESCRIPTION
Bug found in https://github.com/FluxML/Flux.jl/pull/1901