### PR TITLE
Add `Lookahead` optimiser

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -25,6 +25,7 @@ Optimisers.ClipGrad
 Optimisers.ClipNorm
 Optimisers.WeightDecay
 Optimisers.OptimiserChain
+Optimisers.Lookahead
 ```
 
 ## Model Interface

--- a/src/Optimisers.jl
+++ b/src/Optimisers.jl
@@ -11,7 +11,7 @@ export destructure, total, total2
 include("rules.jl")
 export Descent, ADAM, Momentum, Nesterov, RMSProp,
        ADAGrad, AdaMax, ADADelta, AMSGrad, NADAM, ADAMW, RADAM, OADAM, AdaBelief,
-       WeightDecay, ClipGrad, ClipNorm, OptimiserChain
+       WeightDecay, ClipGrad, ClipNorm, OptimiserChain, Lookahead
 
 """
     Optimisers.apply!(rule::RuleType, state, parameters, gradient) -> (state, gradient)

--- a/test/rules.jl
+++ b/test/rules.jl
@@ -14,10 +14,13 @@ RULES = [
   OptimiserChain(ClipNorm(), ADAM(0.001)),
   OptimiserChain(ClipGrad(0.5), Momentum()),
   OptimiserChain(WeightDecay(), OADAM(), ClipGrad(1)),
+  # Lookahead
+  Lookahead(), Lookahead(0.5, 5, ADAMW(0.001))
 ]
 
 name(o) = typeof(o).name.name  # just for printing testset headings
 name(o::OptimiserChain) = join(name.(o.opts), " → ")
+name(o::Lookahead) = string("LookAhead(", name(o.inner), ")")
 
 LOG = Dict()  # for debugging these testsets, this makes it easy to plot each optimiser's loss
 


### PR DESCRIPTION
This is simpler than the version in https://github.com/FluxML/Flux.jl/pull/969, as it has no special handling for momentum, or not yet. 

It's unusual in that I think it needs to be written as an `update!` rule, not an `apply!` rule.

Cc @chengchingwen who wrote the Flux PR.