### PR TITLE
Attempt to fix #62

### DIFF
--- a/src/destructure.jl
+++ b/src/destructure.jl
@@ -91,7 +91,7 @@ _getat(y::AbstractArray, o::Int, flat::AbstractVector) =
 
 function _trainable_biwalk(f, x, aux)
   ch, re = functor(typeof(x), x)
-  au, _ = functor(typeof(x), aux)
+  au, _ = functor(aux) 
   _trainmap(f, ch, _trainable(x), au) |> re
 end
 
@@ -103,7 +103,7 @@ end
 
 function _Tangent_biwalk(f, x, aux)  # use with prune = NoT
   ch, re = functor(typeof(x), x)
-  au, _ = functor(typeof(x), aux)
+  au, _ = functor(aux)
   y = _trainmap(f, ch, _trainable(x), au)
   y isa Tuple{} && return NoT
   p = ProjectTo(x)
@@ -126,7 +126,7 @@ ChainRulesCore.@non_differentiable _zero(x)
 function _grad!(x, dx, off, flat::AbstractVector)
   x′, _ = functor(typeof(x), x)
   dx′, _ = functor(typeof(x), base(dx))
-  off′, _ = functor(typeof(x), off)
+  off′, _ = functor(off)
   foreach((xᵢ, dxᵢ, oᵢ) -> _grad!(xᵢ, dxᵢ, oᵢ, flat), x′, dx′, off′)
   flat
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,6 +13,13 @@ struct TwoThirds a; b; c; end
 Functors.@functor TwoThirds (a, c)
 Optimisers.trainable(x::TwoThirds) = (a = x.a,)
 
+struct Skip{T}  # like Flux 0.12's Chain
+  layers::T
+  Skip(ls...) = new{typeof(ls)}(ls)
+end
+Base.getindex(x::Skip, i::Integer) = x.layers[i]
+Functors.functor(::Type{<:Skip}, x) = x.layers, ls -> Skip(ls...)
+
 @testset verbose=true "Optimisers.jl" begin
   @testset verbose=true "Features" begin
 
@@ -163,6 +170,16 @@ Optimisers.trainable(x::TwoThirds) = (a = x.a,)
       @test Optimisers.setup(ADAMW(), m1) isa Tuple
       m2 = (rand(3), m, rand(3), m, rand(3))  # illegal
       @test_throws ArgumentError Optimisers.setup(ADAMW(), m2)
+    end
+
+    @testset "issue 62" begin
+      m62 = (s = Skip([1.0, 2.0], Foo([3.0], false)), t = [4.0, 5.0])
+      s62 = Optimisers.setup(Descent(), m62)
+      g62 = gradient(m -> m.s[2].x[1] + 3 * m.t[2], m62)
+      s, m = Optimisers.update(s62, m62, g62...)
+      @test m.s isa Skip
+      @test m.s[2].x ≈ [2.9]
+      @test m.t ≈ [4, 4.7]
     end
 
   end


### PR DESCRIPTION
This tries to fix #62 by using `functor(typeof(x), dx)` only for gradients, and `functor(aux)` for the tree of offsets made by `destructure`. 

But it doesn't quite work, as for an array of arrays like `x = [[1.0, 2.0]]` the offset structure is something like `o = [4]` which is leaflike. 