### PR TITLE
Readme links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Optimisers.jl
 
-[![][docs-stable-img]][docs-stable-url]
+<!-- [![][docs-stable-img]][docs-stable-url] -->
 [![][docs-dev-img]][docs-dev-url]
 [![][action-img]][action-url]
 [![][coverage-img]][coverage-url] 
@@ -17,9 +17,10 @@
 [coverage-img]: https://codecov.io/gh/FluxML/Optimisers.jl/branch/master/graph/badge.svg
 [coverage-url]: https://codecov.io/gh/FluxML/Optimisers.jl
 
-Optimisers.jl defines many standard optimisers and utilities for learning loops.
+Optimisers.jl defines many standard optimisers, and some utilities for learning loops.
 
-The API for defining an optimiser, and using it is simple.
+This is the future of training for [Flux.jl](https://github.com/FluxML/Flux.jl) neural networks,
+but can be used separately on anything understood by [Functors.jl](https://github.com/FluxML/Functors.jl).
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 [coverage-img]: https://codecov.io/gh/FluxML/Optimisers.jl/branch/master/graph/badge.svg
 [coverage-url]: https://codecov.io/gh/FluxML/Optimisers.jl
 
-Optimisers.jl defines many standard optimisers, and tools for applying them to deeply nested models.
+Optimisers.jl defines many standard gradient-based optimisation rules, and tools for applying them to deeply nested models.
 
 This is the future of training for [Flux.jl](https://github.com/FluxML/Flux.jl) neural networks,
 but it can be used separately on anything understood by [Functors.jl](https://github.com/FluxML/Functors.jl).

--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@
 [coverage-img]: https://codecov.io/gh/FluxML/Optimisers.jl/branch/master/graph/badge.svg
 [coverage-url]: https://codecov.io/gh/FluxML/Optimisers.jl
 
-Optimisers.jl defines many standard optimisers, and some utilities for learning loops.
+Optimisers.jl defines many standard optimisers, and tools for applying them to deeply nested models.
 
 This is the future of training for [Flux.jl](https://github.com/FluxML/Flux.jl) neural networks,
-but can be used separately on anything understood by [Functors.jl](https://github.com/FluxML/Functors.jl).
+but it can be used separately on anything understood by [Functors.jl](https://github.com/FluxML/Functors.jl).
 
 ## Installation
 


### PR DESCRIPTION
This hides the broken "stable" docs, until someone figures out https://github.com/FluxML/Optimisers.jl/issues/25 . 

And adds links to Flux & Functors. 