### PR TITLE
Re-allocate Buffer if the incoming `eltypes` don't match preallocated one

### DIFF
--- a/src/destructure.jl
+++ b/src/destructure.jl
@@ -130,12 +130,19 @@ function _grad!(x, dx, off, flat::AbstractVector)
   foreach((xᵢ, dxᵢ, oᵢ) -> _grad!(xᵢ, dxᵢ, oᵢ, flat), x′, dx′, off′)
   flat
 end
-function _grad!(x, dx, off::Integer, flat::AbstractVector)
+function _grad!(x::T, dx::T, off::Integer, flat::AbstractVector) where T
   @views flat[off .+ (1:length(x))] .+= vec(dx)  # must visit all tied nodes
   flat
 end
 _grad!(x, dx::Zero, off, flat::AbstractVector) = dx
 _grad!(x, dx::Zero, off::Integer, flat::AbstractVector) = dx  # ambiguity
+
+function _grad!(x::T, dx::S, off::Integer, flat::AbstractVector) where {T, S}
+  flat = similar(dx, length(flat))
+  @views flat[off .+ (1:length(x))] .+= vec(dx)  # must visit all tied nodes
+  flat
+end
+
 
 # These are only needed for 2nd derivatives:
 function ChainRulesCore.rrule(::typeof(_grad!), x, dx, off, flat)


### PR DESCRIPTION
Currently, the `flat` vector is stored inside the `Restructure` struct. It therefore assumes that incoming parameters also match the same eltype of the model. This will fail in mixed-mode AD, using struct-of-arrays, etc. To combat that, try to reallocate a buffer that can hold in the actual new parameters properly. Note that with mixed-precision, we also pay for conversion (and therefore allocation) with every operation. cc @ChrisRackauckas MWE:

```Julia
using DiffEqFlux, OrdinaryDiffEq, Test

u0 = Float32[2.0; 0.0]
             datasize = 30
             tspan = (0.0f0, 1.5f0)

function trueODEfunc(du, u, p, t)
    true_A = [-0.1 2.0; -2.0 -0.1]
    du .= ((u .^ 3)'true_A)'
end
t = range(tspan[1], tspan[2], length=datasize)
prob = ODEProblem(trueODEfunc, u0, tspan)
ode_data = Array(solve(prob, Tsit5(), saveat=t))

model = Chain(x -> x .^ 3,
              Dense(2, 50, tanh),
              Dense(50, 2))
neuralde = NeuralODE(model, tspan, Rodas5(), saveat=t, reltol=1e-7, abstol=1e-9)

function predict_n_ode()
  neuralde(u0)
end
loss_n_ode() = sum(abs2, ode_data .- predict_n_ode())

data = Iterators.repeated((), 10)
opt = ADAM(0.1)
cb = function () #callback function to observe training
   display(loss_n_ode())
end

# Display the ODE with the initial parameter values.
cb()

neuralde = NeuralODE(model, tspan, Rodas5(), saveat=t, reltol=1e-7, abstol=1e-9)
ps = Flux.params(neuralde)
loss1 = loss_n_ode()
Flux.train!(loss_n_ode, ps, data, opt, cb=cb)
```

It might be good to update the actual struct else it would lie about the actual contents of the parameters. This would mean making `Restructure` mutable.

This still needs tests before merging; and some test failures are expected since we have to accumulate the gradients properly still