### PR TITLE
Fix #62

### DIFF
--- a/src/destructure.jl
+++ b/src/destructure.jl
@@ -91,7 +91,7 @@ _getat(y::AbstractArray, o::Int, flat::AbstractVector) =
 
 function _trainable_biwalk(f, x, aux)
   ch, re = functor(typeof(x), x)
-  au, _ = functor(typeof(x), aux)
+  au, _ = functor(aux) 
   _trainmap(f, ch, _trainable(x), au) |> re
 end
 
@@ -103,7 +103,7 @@ end
 
 function _Tangent_biwalk(f, x, aux)  # use with prune = NoT
   ch, re = functor(typeof(x), x)
-  au, _ = functor(typeof(x), aux)
+  au, _ = functor(aux)
   y = _trainmap(f, ch, _trainable(x), au)
   y isa Tuple{} && return NoT
   p = ProjectTo(x)
@@ -126,7 +126,7 @@ ChainRulesCore.@non_differentiable _zero(x)
 function _grad!(x, dx, off, flat::AbstractVector)
   x′, _ = functor(typeof(x), x)
   dx′, _ = functor(typeof(x), base(dx))
-  off′, _ = functor(typeof(x), off)
+  off′, _ = functor(off)
   foreach((xᵢ, dxᵢ, oᵢ) -> _grad!(xᵢ, dxᵢ, oᵢ, flat), x′, dx′, off′)
   flat
 end

--- a/test/destructure.jl
+++ b/test/destructure.jl
@@ -203,10 +203,10 @@ end
     re(w)[2].y[1]
   end == ([0,0,1,0],)
 
-  gradient(sk) do x
+  @test gradient(sk) do x
     w, _ = destructure(x)
-    w[1]
-  end
+    w[1] + w[4]
+  end == ((layers = ([1.0, 0.0], (x = nothing, y = [0.0, 1.0])),),)
 #=
 
 ERROR: ArgumentError: Tangent for the primal Skip{Tuple{Vector{Float64}, NamedTuple{(:x, :y), Tuple{Int64, Vector{Float64}}}}} should be backed by a NamedTuple type, not by Tuple{Vector{Float64}, ChainRulesCore.Tangent{NamedTuple{(:x, :y), Tuple{Int64, Vector{Float64}}}, NamedTuple{(:x, :y), Tuple{ChainRulesCore.NoTangent, Vector{Float64}}}}}.

--- a/test/destructure.jl
+++ b/test/destructure.jl
@@ -49,7 +49,7 @@ m9 = (a = m1, b = mat, c = [mat, m1])
   m8′ = destructure(m8)[2](1:5)
   @test m8′[1].x === m8′[1].y
   @test m8′[2].b.y === false
-  @test m8′[3][1] == [5.0] # broken
+  @test m8′[3][1] == [5.0]
 
   m9′ = destructure(m9)[2](10:10:70)
   @test m9′.b === m9′.c[1]
@@ -130,7 +130,7 @@ end
 
   v8, re8 = destructure(m8)
   @test gradient(x -> sum(abs2, re8(x)[1].y), v8)[1] == [2,4,6,0,0]
-  @test gradient(x -> only(sum(re8(x)[3]))^2, v8)[1] == [0,0,0,0,10]  # fails
+  @test gradient(x -> only(sum(re8(x)[3]))^2, v8)[1] == [0,0,0,0,10]
 
   re9 = destructure(m9)[2]
   @test gradient(x -> sum(abs2, re9(x).c[1]), 1:7)[1] == [0,0,0, 8,10,12,14]
@@ -203,10 +203,10 @@ end
     re(w)[2].y[1]
   end == ([0,0,1,0],)
 
-  # gradient(sk) do x
-  #   w, _ = destructure(x)
-  #   w[1]
-  # end
+  gradient(sk) do x
+    w, _ = destructure(x)
+    w[1]
+  end
 #=
 
 ERROR: ArgumentError: Tangent for the primal Skip{Tuple{Vector{Float64}, NamedTuple{(:x, :y), Tuple{Int64, Vector{Float64}}}}} should be backed by a NamedTuple type, not by Tuple{Vector{Float64}, ChainRulesCore.Tangent{NamedTuple{(:x, :y), Tuple{Int64, Vector{Float64}}}, NamedTuple{(:x, :y), Tuple{ChainRulesCore.NoTangent, Vector{Float64}}}}}.

--- a/test/destructure.jl
+++ b/test/destructure.jl
@@ -79,7 +79,7 @@ end
   g8 = gradient(m -> sum(abs2, destructure(m)[1]), m8)[1]
   @test g8[1].x == [2,4,6]
   @test g8[2].b.x == [8]
-  @test g8[3] == [[10.0]]  # fails
+  @test g8[3] == [[10.0]]
 
   g9 = gradient(m -> sum(sqrt, destructure(m)[1]), m9)[1]
   @test g9.c === nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,6 +13,13 @@ struct TwoThirds a; b; c; end
 Functors.@functor TwoThirds (a, c)
 Optimisers.trainable(x::TwoThirds) = (a = x.a,)
 
+struct Skip{T}  # like Flux 0.12's Chain
+  layers::T
+  Skip(ls...) = new{typeof(ls)}(ls)
+end
+Base.getindex(x::Skip, i::Integer) = x.layers[i]
+Functors.functor(::Type{<:Skip}, x) = x.layers, ls -> Skip(ls...)
+
 @testset verbose=true "Optimisers.jl" begin
   @testset verbose=true "Features" begin
 
@@ -163,6 +170,16 @@ Optimisers.trainable(x::TwoThirds) = (a = x.a,)
       @test Optimisers.setup(ADAMW(), m1) isa Tuple
       m2 = (rand(3), m, rand(3), m, rand(3))  # illegal
       @test_throws ArgumentError Optimisers.setup(ADAMW(), m2)
+    end
+
+    @testset "issue 62" begin
+      m62 = (s = Skip([1.0, 2.0], Foo([3.0], false)), t = [4.0, 5.0])
+      s62 = Optimisers.setup(Descent(), m62)
+      g62 = gradient(m -> m.s[2].x[1] + 3 * m.t[2], m62)
+      s, m = Optimisers.update(s62, m62, g62...)
+      @test m.s isa Skip
+      @test m.s[2].x ≈ [2.9]
+      @test m.t ≈ [4, 4.7]
     end
 
   end


### PR DESCRIPTION
This adds a couple small changes on top of [this draft PR](https://github.com/FluxML/Optimisers.jl/pull/63) in order to fix #62:

1. Wrap offset indices in a dummy struct `Offset` to fix the issue mentioned in #63 for array of arrays, where e.g. the offset structure for `x = [[1.0, 2.0]]` is now something like `o = [Offset(4)]` which is not leaflike, compared to `o = [4]` previously. Also opens the door to storing more information in this wrapper struct (original array size? eltype?), but doesn't seem to be necessary at this time
2. [`y = backing(re(y))`](https://github.com/jondeuce/Optimisers.jl/blob/927e095ae1f4742a27cc0710132ea1000ad1e20e/src/destructure.jl#L119) allows for `functor(x)` to return children which aren't its own fields: first restructure the gradient, then extract the `NamedTuple` backing for `Tangent`. It has the added benefit of adding some symmetry with `_trainable_biwalk` which naturally restructures the output of `_trainmap`, whereas `_Tangent_biwalk` previously did not