### PR TITLE
Add doc section about `destructure`

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -32,8 +32,8 @@ It of course also makes it easier to store the state.
 
 ## Usage with [Flux.jl](https://github.com/FluxML/Flux.jl)
 
-To apply such an optimiser to a whole model, `setup` builds a tree containing any initial
-state for every trainable array. Then at each step, `update` uses this and the gradient
+To apply such an optimiser to a whole model, [`setup`](@ref) builds a tree containing any initial
+state for every trainable array. Then at each step, [`update`](@ref) uses this and the gradient
 to adjust the model:
 
 ```julia
@@ -67,7 +67,7 @@ This `∇model` is another tree structure, rather than the dictionary-like objec
 Zygote's "implicit" mode `gradient(() -> loss(...), Flux.params(model))` -- see 
 [Zygote's documentation](https://fluxml.ai/Zygote.jl/dev/#Explicit-and-Implicit-Parameters-1) for more about this difference.
 
-There is also `Optimisers.update!` which similarly returns a new model and new state,
+There is also [`Optimisers.update!`](@ref) which similarly returns a new model and new state,
 but is free to mutate arrays within the old one for efficiency.
 The method of `apply!` you write is likewise free to mutate arrays within its state;
 they are defensively copied when this rule is used with `update`.
@@ -148,7 +148,7 @@ When defining new layers, these can be specified if necessary by overloading [`t
 By default, all numeric arrays visible to [Functors.jl](https://github.com/FluxML/Functors.jl)
 are assumed to contain trainable parameters.
 
-Lux stores only the trainable parameters in `param`.
+Lux stores only the trainable parameters in `params`.
 This can also be flattened to a plain `Vector` in the same way:
 
 ```julia

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -159,7 +159,7 @@ lux_model = Chain(
           BatchNorm(5, relu), 
           Conv((3, 3), 5 => 3, stride=16),
         )
-params, lux_state = Lux.setup(Random.GLOBAL_RNG, lux_model);
+params, lux_state = Lux.setup(Random.default_rng(), lux_model);
 
 flat, re = destructure(params)
 st = Optimisers.setup(rule, flat)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -152,24 +152,14 @@ Lux stores only the trainable parameters in `params`.
 This can also be flattened to a plain `Vector` in the same way:
 
 ```julia
-using NNlib, Random
-
-lux_model = Chain(
-          Conv((3, 3), 3 => 5, pad=1, bias=false), 
-          BatchNorm(5, relu), 
-          Conv((3, 3), 5 => 3, stride=16),
-        )
 params, lux_state = Lux.setup(Random.default_rng(), lux_model);
 
 flat, re = destructure(params)
-st = Optimisers.setup(rule, flat)
 
-∇flat, = Zygote.gradient(flat) do v
+∇flat = ForwardDiff.gradient(flat) do v
   p = re(v)  # rebuild an object like params
   y, _ = Lux.apply(lux_model, images, p, lux_state)
   sum(y)
 end
-
-st, flat = Optimisers.update(st, flat, ∇flat)
 ```
 


### PR DESCRIPTION
Continues the expansion of the main doc page from #80, to explain `destructure` a bit, since that's the other main feature of this package.