### PR TITLE
Restrict the types of learning rates

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -22,6 +22,7 @@ Leaf(rule, state; frozen::Bool = false) = Leaf(rule, state, frozen)
 Base.:(==)(a::Leaf, b::Leaf) = children(a) == children(b)
 
 function setup(rule::AbstractRule, model)
+  checksign(rule)
   cache = IdDict()
   tree = _setup(rule, model; cache)
   isempty(cache) && @warn "setup found no trainable parameters in this model"
@@ -51,6 +52,10 @@ function Base.show(io::IO, ℓ::Leaf; colour = ℓ.frozen ? :cyan : :green)
   show(ioc, ℓ.state)
   printstyled(io, ℓ.frozen ? ", frozen = true)" : ")"; color = colour)
 end
+
+checksign(η::Real, s::Symbol) = η < 0 && throw(DomainError(s, "the learning rate cannot be negative, got $η"))
+checksign(η, s::Symbol) = nothing  # someone had a use for complex Descent
+checksign(rule::AbstractRule) = hasproperty(rule, :eta) && checksign(rule.eta, typeof(rule).name.name)
 
 ###
 ### update

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -10,10 +10,10 @@
     Descent(η = 1f-1)
 
 Classic gradient descent optimiser with learning rate `η`.
-For each parameter `p` and its gradient `dp`, this runs `p -= η*dp`.
+For each parameter `p` and its gradient `dp`, the update is `p -= η * dp`.
 
 # Parameters
-- Learning rate (`η`): Amount by which gradients are discounted before updating
+- Learning rate (`η`): Factor by which gradients are discounted before updating
                        the weights.
 """
 struct Descent{T<Number} <: AbstractRule
@@ -35,7 +35,7 @@ end
 Gradient descent optimizer with learning rate `η` and momentum `ρ`.
 
 # Parameters
-- Learning rate (`η`): Amount by which gradients are discounted before updating
+- Learning rate (`η`): Factor by which gradients are discounted before updating
                        the weights.
 - Momentum (`ρ`): Controls the acceleration of gradient descent in the
                   prominent direction, in effect dampening oscillations.
@@ -61,7 +61,7 @@ end
 Gradient descent optimizer with learning rate `η` and Nesterov momentum `ρ`.
 
 # Parameters
-- Learning rate (`η`): Amount by which gradients are discounted before updating
+- Learning rate (`η`): Factor by which gradients are discounted before updating
                        the weights.
 - Nesterov momentum (`ρ`): Controls the acceleration of gradient descent in the
                            prominent direction, in effect dampening oscillations.
@@ -95,7 +95,7 @@ generally don't need tuning.
 gradients by an estimate their variance, instead of their second moment.
 
 # Parameters
-- Learning rate (`η`): Amount by which gradients are discounted before updating
+- Learning rate (`η`): Factor by which gradients are discounted before updating
                        the weights.
 - Momentum (`ρ`): Controls the acceleration of gradient descent in the
                   prominent direction, in effect dampening oscillations.
@@ -190,7 +190,7 @@ end
 [Adam](https://arxiv.org/abs/1412.6980) optimiser.
 
 # Parameters
-- Learning rate (`η`): Amount by which gradients are discounted before updating
+- Learning rate (`η`): Factor by which gradients are discounted before updating
                        the weights.
 - Decay of momentums (`β::Tuple`): Exponential decay for the first (β1) and the
                                    second (β2) momentum estimate.
@@ -223,7 +223,7 @@ end
 [Rectified Adam](https://arxiv.org/abs/1908.03265) optimizer.
 
 # Parameters
-- Learning rate (`η`): Amount by which gradients are discounted before updating
+- Learning rate (`η`): Factor by which gradients are discounted before updating
                        the weights.
 - Decay of momentums (`β::Tuple`): Exponential decay for the first (β1) and the
                                    second (β2) momentum estimate.
@@ -264,7 +264,7 @@ end
 [AdaMax](https://arxiv.org/abs/1412.6980) is a variant of Adam based on the ∞-norm.
 
 # Parameters
-- Learning rate (`η`): Amount by which gradients are discounted before updating
+- Learning rate (`η`): Factor by which gradients are discounted before updating
                        the weights.
 - Decay of momentums (`β::Tuple`): Exponential decay for the first (β1) and the
                                    second (β2) momentum estimate.
@@ -298,7 +298,7 @@ end
 is a variant of Adam adding an "optimistic" term suitable for adversarial training.
 
 # Parameters
-- Learning rate (`η`): Amount by which gradients are discounted before updating
+- Learning rate (`η`): Factor by which gradients are discounted before updating
                        the weights.
 - Decay of momentums (`β::Tuple`): Exponential decay for the first (β1) and the
                                    second (β2) momentum estimate.
@@ -335,7 +335,7 @@ parameter specific learning rates based on how frequently it is updated.
 Parameters don't need tuning.
 
 # Parameters
-- Learning rate (`η`): Amount by which gradients are discounted before updating
+- Learning rate (`η`): Factor by which gradients are discounted before updating
                        the weights.
 - Machine epsilon (`ϵ`): Constant to prevent division by zero
                          (no need to change default)
@@ -397,7 +397,7 @@ The [AMSGrad](https://openreview.net/forum?id=ryQu7f-RZ) version of the Adam
 optimiser. Parameters don't need tuning.
 
 # Parameters
-- Learning rate (`η`): Amount by which gradients are discounted before updating
+- Learning rate (`η`): Factor by which gradients are discounted before updating
                        the weights.
 - Decay of momentums (`β::Tuple`): Exponential decay for the first (β1) and the
                                    second (β2) momentum estimate.
@@ -433,7 +433,7 @@ end
 Parameters don't need tuning.
 
 # Parameters
-- Learning rate (`η`): Amount by which gradients are discounted before updating
+- Learning rate (`η`): Factor by which gradients are discounted before updating
                        the weights.
 - Decay of momentums (`β::Tuple`): Exponential decay for the first (β1) and the
                                    second (β2) momentum estimate.
@@ -469,7 +469,7 @@ end
 weight decay regularization.
 
 # Parameters
-- Learning rate (`η`): Amount by which gradients are discounted before updating
+- Learning rate (`η`): Factor by which gradients are discounted before updating
                        the weights.
 - Decay of momentums (`β::Tuple`): Exponential decay for the first (β1) and the
                                    second (β2) momentum estimate.
@@ -487,7 +487,7 @@ The [AdaBelief](https://arxiv.org/abs/2010.07468) optimiser is a variant of the 
 Adam optimiser.
 
 # Parameters
-- Learning rate (`η`): Amount by which gradients are discounted before updating
+- Learning rate (`η`): Factor by which gradients are discounted before updating
                        the weights.
 - Decay of momentums (`β::Tuple`): Exponential decay for the first (β1) and the
                                    second (β2) momentum estimate.

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -16,7 +16,7 @@ For each parameter `p` and its gradient `dp`, this runs `p -= η*dp`.
 - Learning rate (`η`): Amount by which gradients are discounted before updating
                        the weights.
 """
-struct Descent{T} <: AbstractRule
+struct Descent{T<Number} <: AbstractRule
   eta::T
 end
 Descent() = Descent(1f-1)
@@ -40,7 +40,7 @@ Gradient descent optimizer with learning rate `η` and momentum `ρ`.
 - Momentum (`ρ`): Controls the acceleration of gradient descent in the
                   prominent direction, in effect dampening oscillations.
 """
-struct Momentum{T} <: AbstractRule
+struct Momentum{T<:Real} <: AbstractRule
   eta::T
   rho::T
 end
@@ -66,7 +66,7 @@ Gradient descent optimizer with learning rate `η` and Nesterov momentum `ρ`.
 - Nesterov momentum (`ρ`): Controls the acceleration of gradient descent in the
                            prominent direction, in effect dampening oscillations.
 """
-struct Nesterov{T} <: AbstractRule
+struct Nesterov{T<:Real} <: AbstractRule
   eta::T
   rho::T
 end
@@ -104,7 +104,7 @@ gradients by an estimate their variance, instead of their second moment.
 - Keyword `centred` (or `centered`): Indicates whether to use centred variant
                                      of the algorithm.
 """
-struct RMSProp{T} <: AbstractRule
+struct RMSProp{T<:Real} <: AbstractRule
   eta::T
   rho::T
   epsilon::T
@@ -197,7 +197,7 @@ end
 - Machine epsilon (`ϵ`): Constant to prevent division by zero
                          (no need to change default)
 """
-struct Adam{T} <: AbstractRule
+struct Adam{T<:Real} <: AbstractRule
   eta::T
   beta::Tuple{T, T}
   epsilon::T
@@ -230,7 +230,7 @@ end
 - Machine epsilon (`ϵ`): Constant to prevent division by zero
                          (no need to change default)
 """
-struct RAdam{T} <: AbstractRule
+struct RAdam{T<:Real} <: AbstractRule
   eta::T
   beta::Tuple{T, T}
   epsilon::T
@@ -271,7 +271,7 @@ end
 - Machine epsilon (`ϵ`): Constant to prevent division by zero
                          (no need to change default)
 """
-struct AdaMax{T} <: AbstractRule
+struct AdaMax{T<:Real} <: AbstractRule
   eta::T
   beta::Tuple{T, T}
   epsilon::T
@@ -305,7 +305,7 @@ is a variant of Adam adding an "optimistic" term suitable for adversarial traini
 - Machine epsilon (`ϵ`): Constant to prevent division by zero
                          (no need to change default)
 """
-struct OAdam{T} <: AbstractRule
+struct OAdam{T<:Real} <: AbstractRule
   eta::T
   beta::Tuple{T, T}
   epsilon::T
@@ -340,7 +340,7 @@ Parameters don't need tuning.
 - Machine epsilon (`ϵ`): Constant to prevent division by zero
                          (no need to change default)
 """
-struct AdaGrad{T} <: AbstractRule
+struct AdaGrad{T<:Real} <: AbstractRule
   eta::T
   epsilon::T
 end
@@ -370,7 +370,7 @@ Parameters don't need tuning.
 - Machine epsilon (`ϵ`): Constant to prevent division by zero
                          (no need to change default)
 """
-struct AdaDelta{T} <: AbstractRule
+struct AdaDelta{T<:Real} <: AbstractRule
   rho::T
   epsilon::T
 end
@@ -404,7 +404,7 @@ optimiser. Parameters don't need tuning.
 - Machine epsilon (`ϵ`): Constant to prevent division by zero
                          (no need to change default)
 """
-struct AMSGrad{T} <: AbstractRule
+struct AMSGrad{T<:Real} <: AbstractRule
   eta::T
   beta::Tuple{T, T}
   epsilon::T
@@ -440,7 +440,7 @@ Parameters don't need tuning.
 - Machine epsilon (`ϵ`): Constant to prevent division by zero
                          (no need to change default)
 """
-struct NAdam{T} <: AbstractRule
+struct NAdam{T<:Real} <: AbstractRule
   eta::T
   beta::Tuple{T, T}
   epsilon::T
@@ -494,7 +494,7 @@ Adam optimiser.
 - Machine epsilon (`ϵ::Float32`): Constant to prevent division by zero
                                   (no need to change default)
 """
-struct AdaBelief{T} <: AbstractRule
+struct AdaBelief{T<:Real} <: AbstractRule
   eta::T
   beta::Tuple{T, T}
   epsilon::T
@@ -526,7 +526,7 @@ This is equivalent to adding ``L_2`` regularization with coefficient ``γ`` to t
 # Parameters
 - Weight decay (`γ`): Decay applied to weights during optimisation.
 """
-struct WeightDecay{T} <: AbstractRule
+struct WeightDecay{T<:Real} <: AbstractRule
   gamma::T
 end
 WeightDecay() = WeightDecay(5f-4)

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -12,7 +12,7 @@
 Classic gradient descent optimiser with learning rate `η`.
 For each parameter `p` and its gradient `dp`, the update is `p -= η * dp`.
 
-# Parameters
+# Arguments
 - Learning rate (`η`): Factor by which gradients are discounted before updating
                        the weights.
 """
@@ -34,7 +34,7 @@ end
 
 Gradient descent optimizer with learning rate `η` and momentum `ρ`.
 
-# Parameters
+# Arguments
 - Learning rate (`η`): Factor by which gradients are discounted before updating
                        the weights.
 - Momentum (`ρ`): Controls the acceleration of gradient descent in the
@@ -60,7 +60,7 @@ end
 
 Gradient descent optimizer with learning rate `η` and Nesterov momentum `ρ`.
 
-# Parameters
+# Arguments
 - Learning rate (`η`): Factor by which gradients are discounted before updating
                        the weights.
 - Nesterov momentum (`ρ`): Controls the acceleration of gradient descent in the
@@ -94,7 +94,7 @@ generally don't need tuning.
 [Centred RMSProp](http://arxiv.org/abs/1308.08500) is a variant which normalises
 gradients by an estimate their variance, instead of their second moment.
 
-# Parameters
+# Arguments
 - Learning rate (`η`): Factor by which gradients are discounted before updating
                        the weights.
 - Momentum (`ρ`): Controls the acceleration of gradient descent in the
@@ -149,8 +149,8 @@ Optimizer using the
 [Rprop](https://ieeexplore.ieee.org/document/298623) algorithm. A full-batch
 learning algorithm that depends only on the sign of the gradient.
 
-# Parameters
-- Learning rate (`η`): Amount by which gradients are discounted before updating
+# Arguments
+- Learning rate (`η`): Factor by which gradients are discounted before updating
                        the weights.
 
 - Scaling factors (`ℓ::Tuple`): Multiplicative increase and decrease factors.
@@ -165,7 +165,7 @@ end
 
 Rprop(η = 1f-3, ℓ = (5f-1, 1.2f0), Γ = (1f-6, 50f0)) = Rprop{typeof(η)}(η, ℓ, Γ)
 
-init(o::Rprop, x::AbstractArray) = (zero(x), onevalue(o.eta, x))
+init(o::Rprop, x::AbstractArray) = (zero(x), onevalue(o.eta, x))  # will adjust work right here??
 
 function apply!(o::Rprop, state, x, dx)
     T = eltype(x)
@@ -189,7 +189,7 @@ end
 
 [Adam](https://arxiv.org/abs/1412.6980) optimiser.
 
-# Parameters
+# Arguments
 - Learning rate (`η`): Factor by which gradients are discounted before updating
                        the weights.
 - Decay of momentums (`β::Tuple`): Exponential decay for the first (β1) and the
@@ -222,7 +222,7 @@ end
 
 [Rectified Adam](https://arxiv.org/abs/1908.03265) optimizer.
 
-# Parameters
+# Arguments
 - Learning rate (`η`): Factor by which gradients are discounted before updating
                        the weights.
 - Decay of momentums (`β::Tuple`): Exponential decay for the first (β1) and the
@@ -263,7 +263,7 @@ end
 
 [AdaMax](https://arxiv.org/abs/1412.6980) is a variant of Adam based on the ∞-norm.
 
-# Parameters
+# Arguments
 - Learning rate (`η`): Factor by which gradients are discounted before updating
                        the weights.
 - Decay of momentums (`β::Tuple`): Exponential decay for the first (β1) and the
@@ -297,7 +297,7 @@ end
 [OAdam](https://arxiv.org/abs/1711.00141) (Optimistic Adam)
 is a variant of Adam adding an "optimistic" term suitable for adversarial training.
 
-# Parameters
+# Arguments
 - Learning rate (`η`): Factor by which gradients are discounted before updating
                        the weights.
 - Decay of momentums (`β::Tuple`): Exponential decay for the first (β1) and the
@@ -334,7 +334,7 @@ end
 parameter specific learning rates based on how frequently it is updated.
 Parameters don't need tuning.
 
-# Parameters
+# Arguments
 - Learning rate (`η`): Factor by which gradients are discounted before updating
                        the weights.
 - Machine epsilon (`ϵ`): Constant to prevent division by zero
@@ -365,7 +365,7 @@ end
 rate based on a window of past gradient updates.
 Parameters don't need tuning.
 
-# Parameters
+# Arguments
 - Rho (`ρ`): Factor by which the gradient is decayed at each time step.
 - Machine epsilon (`ϵ`): Constant to prevent division by zero
                          (no need to change default)
@@ -396,7 +396,7 @@ end
 The [AMSGrad](https://openreview.net/forum?id=ryQu7f-RZ) version of the Adam
 optimiser. Parameters don't need tuning.
 
-# Parameters
+# Arguments
 - Learning rate (`η`): Factor by which gradients are discounted before updating
                        the weights.
 - Decay of momentums (`β::Tuple`): Exponential decay for the first (β1) and the
@@ -432,7 +432,7 @@ end
 [NAdam](https://openreview.net/forum?id=OM0jvwB8jIp57ZJjtNEZ) is a Nesterov variant of Adam.
 Parameters don't need tuning.
 
-# Parameters
+# Arguments
 - Learning rate (`η`): Factor by which gradients are discounted before updating
                        the weights.
 - Decay of momentums (`β::Tuple`): Exponential decay for the first (β1) and the
@@ -468,7 +468,7 @@ end
 [AdamW](https://arxiv.org/abs/1711.05101) is a variant of Adam fixing (as in repairing) its
 weight decay regularization.
 
-# Parameters
+# Arguments
 - Learning rate (`η`): Factor by which gradients are discounted before updating
                        the weights.
 - Decay of momentums (`β::Tuple`): Exponential decay for the first (β1) and the
@@ -486,7 +486,7 @@ AdamW(η = 1f-3, β = (9f-1, 9.99f-1), γ = 0, ϵ = eps(typeof(η))) =
 The [AdaBelief](https://arxiv.org/abs/2010.07468) optimiser is a variant of the well-known
 Adam optimiser.
 
-# Parameters
+# Arguments
 - Learning rate (`η`): Factor by which gradients are discounted before updating
                        the weights.
 - Decay of momentums (`β::Tuple`): Exponential decay for the first (β1) and the
@@ -523,7 +523,7 @@ subtracted from `x`.
 Typically composed  with other optimisers as the first transformation in an [`OptimiserChain`](@ref).
 This is equivalent to adding ``L_2`` regularization with coefficient ``γ`` to the loss.
 
-# Parameters
+# Arguments
 - Weight decay (`γ`): Decay applied to weights during optimisation.
 """
 struct WeightDecay{T<:Real} <: AbstractRule

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -16,7 +16,7 @@ For each parameter `p` and its gradient `dp`, the update is `p -= η * dp`.
 - Learning rate (`η`): Factor by which gradients are discounted before updating
                        the weights.
 """
-struct Descent{T<Number} <: AbstractRule
+struct Descent{T<:Number} <: AbstractRule
   eta::T
 end
 Descent() = Descent(1f-1)

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -637,3 +637,5 @@ end
 
 adjust(ℓ::OptimiserChain, eta::Real) = OptimiserChain(map(opt -> adjust(opt, eta), ℓ.opts)...)
 adjust(ℓ::OptimiserChain; kw...) = OptimiserChain(map(opt -> adjust(opt; kw...), ℓ.opts)...)
+
+checksign(o::OptimiserChain) = foreach(checksign, o.opts)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -265,6 +265,11 @@ end
       @test sc1.γ.state[2][1] ≈ [0.1, 0.2, 0.2]
     end
 
+    @testset "forbid negative learning rates" begin
+      @test_throws DomainError Optimisers.setup(Momentum(-0.1), rand(3))
+      @test_throws DomainError Optimisers.setup(AdamW(-0.1), rand(3))
+    end
+
     @testset "freeze/thaw" begin
       m = (x=[1.0, 2.0], y=([3.0, 4.0], sin));
       st = Optimisers.setup(Descent(0.1), m);


### PR DESCRIPTION
As discussed starting here https://github.com/FluxML/Optimisers.jl/pull/79#issuecomment-1146022257 

This PR weakens the constraint for gradient descent only to `Descent{T<:Number}`. That rule is so simple that perhaps it should literally do what the formula says, and apparently there are papers using this with complex η. 