### PR TITLE
Add `adjust`

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -34,7 +34,7 @@ Optimisers.OptimiserChain
 Optimisers.setup
 Optimisers.update
 Optimisers.update!
-Optimisers.setup(::Union{Real, AbstractRule}, ::Any)
+Optimisers.adjust(::Any, ::Any)
 ```
 
 Calling `Functors.@functor` on your model's layer types by default causes the

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -34,6 +34,7 @@ Optimisers.OptimiserChain
 Optimisers.setup
 Optimisers.update
 Optimisers.update!
+Optimisers.setup(::Union{Real, AbstractRule}, ::Any)
 ```
 
 Calling `Functors.@functor` on your model's layer types by default causes the

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -34,7 +34,7 @@ Optimisers.OptimiserChain
 Optimisers.setup
 Optimisers.update
 Optimisers.update!
-Optimisers.adjust(::Any, ::Any)
+Optimisers.adjust(::Any, ::Real)
 ```
 
 Calling `Functors.@functor` on your model's layer types by default causes the
@@ -58,4 +58,5 @@ Optimisers.apply!
 Optimisers.init
 Optimisers.@..
 Optimisers.@lazy
+Optimisers.adjust(::AbstractRule, ::Real)
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -8,13 +8,13 @@ These act on one array of parameters:
 ```julia
 # Define a container to hold any optimiser specific parameters (if any):
 struct DecayDescent{T} <: Optimisers.AbstractRule
-  η::T
+  eta::T
 end
 
 # Define an `apply!` rule which encodes how the gradients will be used to
 # update the parameters:
 function Optimisers.apply!(o::DecayDescent, state, x, x̄)
-  newx̄ = (o.η / √state) .* x̄
+  newx̄ = (o.eta / √state) .* x̄
   nextstate = state + 1
   return nextstate, newx̄
 end

--- a/src/Optimisers.jl
+++ b/src/Optimisers.jl
@@ -6,6 +6,8 @@ using LinearAlgebra
 include("interface.jl")
 export AbstractRule
 
+include("adjust.jl")
+
 include("destructure.jl")
 export destructure
 
@@ -54,25 +56,6 @@ julia> Optimisers.init(Momentum(), [1.0, 2.0])
 ```
 """
 init
-
-"""
-    Optimisers.adjust(rule::RuleType, η::Real) -> rule
-
-Replaces the activation rate of the optimisation rule with the given number.
-This method is only called by `setup(η, tree)`, and if `RuleType` has a field
-called `:eta` and the default constructor, then the standard definition will work.
-
-# Example
-```jldoctest
-julia> struct DecayDescent{T} <: Optimisers.AbstractRule  # as in the documentation
-         eta::T
-       end
-
-julia> Optimisers.adjust(DecayDescent(0.1f0), 0.23)  # works automatically
-DecayDescent{Float32}(0.23f0)
-```
-"""
-adjust
 
 """
     Optimisers.setup(rule, model) -> tree
@@ -179,33 +162,5 @@ julia> t  # original state should likewise be discarded
 ```
 """
 update!
-
-"""
-    Optimisers.setup(rule, tree) -> tree
-    Optimisers.setup(η::Real, tree) -> tree
-
-Alters the state `tree = setup(rule, model)` to change the parameters of the optimisation rule,
-without destroying its state. To change just the learning rate, you can provide a number.
-
-# Example
-```jldoctest
-julia> m = (vec = rand(Float32, 2), fun = sin);
-
-julia> st = Optimisers.setup(Nesterov(), m)  # stored momentum is initialised to zero
-(vec = Leaf(Nesterov{Float32}(0.001, 0.9), Float32[0.0, 0.0]), fun = nothing)
-
-julia> st, m = Optimisers.update(st, m, (vec = [14, 92], fun = nothing));  # with fake gradient
-
-julia> st
-(vec = Leaf(Nesterov{Float32}(0.001, 0.9), Float32[-0.014, -0.092]), fun = nothing)
-
-julia> st = Optimisers.setup(0.123, st)  # change learning rate, stored momentum untouched
-(vec = Leaf(Nesterov{Float32}(0.123, 0.9), Float32[-0.014, -0.092]), fun = nothing)
-
-julia> st = Optimisers.setup(Nesterov(0.101, 0.909), st)  # change both η and ρ
-(vec = Leaf(Nesterov{Float64}(0.101, 0.909), Float32[-0.014, -0.092]), fun = nothing)
-```
-"""
-setup(::Union{Real, AbstractRule}, ::Any)
 
 end # module

--- a/src/Optimisers.jl
+++ b/src/Optimisers.jl
@@ -56,7 +56,7 @@ julia> Optimisers.init(Momentum(), [1.0, 2.0])
 init
 
 """
-    Optimisers.adjust(η::Real, rule::RuleType) -> rule
+    Optimisers.adjust(rule::RuleType, η::Real) -> rule
 
 Replaces the activation rate of the optimisation rule with the given number.
 This method is only called by `setup(η, tree)`, and if `RuleType` has a field
@@ -68,7 +68,7 @@ julia> struct DecayDescent{T} <: Optimisers.AbstractRule  # as in the documentat
          eta::T
        end
 
-julia> Optimisers.adjust(0.23, DecayDescent(0.1f0))  # works automatically
+julia> Optimisers.adjust(DecayDescent(0.1f0), 0.23)  # works automatically
 DecayDescent{Float32}(0.23f0)
 ```
 """
@@ -184,7 +184,7 @@ update!
     Optimisers.setup(rule, tree) -> tree
     Optimisers.setup(η::Real, tree) -> tree
 
-Alters the optimiser state from `setup(rule, model)` to change the parameters of the optimisation rule,
+Alters the state `tree = setup(rule, model)` to change the parameters of the optimisation rule,
 without destroying its state. To change just the learning rate, you can provide a number.
 
 # Example

--- a/src/Optimisers.jl
+++ b/src/Optimisers.jl
@@ -161,4 +161,32 @@ julia> t  # original state should likewise be discarded
 """
 update!
 
+"""
+    Optimisers.adjust(rule, tree) -> tree
+    Optimisers.adjust(η::Real, tree) -> tree
+
+Alters the optimiser state from [`setup`](@ref) to change the parameters of the optimisation rule,
+without destroying its state. To change just the learning rate, you can provide a number.
+
+# Example
+```jldoctest
+julia> m = (vec = rand(Float32, 2), fun = sin);
+
+julia> st = Optimisers.setup(Nesterov(), m)
+(vec = Leaf(Nesterov{Float32}(0.001, 0.9), Float32[0.0, 0.0]), fun = nothing)
+
+julia> st, m = Optimisers.update(st, m, (vec = [14, 92], fun = nothing));  # with fake gradient
+
+julia> st
+(vec = Leaf(Nesterov{Float32}(0.001, 0.9), Float32[-0.014, -0.092]), fun = nothing)
+
+julia> st = Optimisers.adjust(0.123, st)  # change learning rate, stored momentum untouched
+(vec = Leaf(Nesterov{Float32}(0.123, 0.9), Float32[-0.014, -0.092]), fun = nothing)
+
+julia> st = Optimisers.adjust(Nesterov(0.101, 0.909), st)  # change both η and ρ
+(vec = Leaf(Nesterov{Float64}(0.101, 0.909), Float32[-0.014, -0.092]), fun = nothing)
+```
+"""
+adjust
+
 end # module

--- a/src/adjust.jl
+++ b/src/adjust.jl
@@ -56,9 +56,10 @@ function _adjust(ℓ::Leaf, a, ok::Ref)
 end
 
 """
-    Optimisers.adjust(rule::RuleType, η::Real) -> rule, flag
+    Optimisers.adjust(rule::RuleType, η::Real) -> rule, changed
 
 Replaces the learning rate of the optimisation rule with the given number.
+
 This method is only called by `adjust(tree, η)`, and if `RuleType` has a field
 called `:eta` and the default constructor, then the standard definition will work.
 It is only necessary to provide a method if your `struct` stores its learning rate
@@ -66,12 +67,18 @@ in a different field.
 
 # Example
 ```jldoctest
+julia> Optimisers.adjust(Adam(), 0.12345)
+(Adam{Float32}(0.12345f0, (0.9f0, 0.999f0), 1.1920929f-7), true)
+
 julia> struct DecayDescent{T} <: Optimisers.AbstractRule  # as in the documentation
          eta::T
        end
 
-julia> Optimisers.adjust(DecayDescent(0.1f0), 0.23)  # works automatically
-(DecayDescent{Float32}(0.23f0), true)
+julia> Optimisers.adjust(DecayDescent(0.1f0), 0.2345)  # works automatically
+(DecayDescent{Float32}(0.2345f0), true)
+
+julia> Optimisers.adjust(ClipNorm(), 0.345)  # does nothing, as this has no learning rate
+(ClipNorm{Float32}(10.0f0, 2.0f0, true), false)
 ```
 """
 function adjust(r::T, η::Real) where T <: AbstractRule

--- a/src/adjust.jl
+++ b/src/adjust.jl
@@ -1,0 +1,108 @@
+
+"""
+    Optimisers.adjust(tree, adj) -> tree
+
+Alters the state `tree = setup(rule, model)` to change the parameters of the
+optimisation rule, without destroying its stored state. Typically used mid-way
+through training.
+* To change just the learning rate, provide a number `adj::Real`.
+* To change all parameters, provide a new rule `adj::AbstractRule`.
+  (This will affect only leaves of the same type.)
+
+# Example
+```jldoctest
+julia> m = (vec = rand(Float32, 2), fun = sin);
+
+julia> st = Optimisers.setup(Nesterov(), m)  # stored momentum is initialised to zero
+(vec = Leaf(Nesterov{Float32}(0.001, 0.9), Float32[0.0, 0.0]), fun = nothing)
+
+julia> st, m = Optimisers.update(st, m, (vec = [16, 88], fun = nothing));  # with fake gradient
+
+julia> st
+(vec = Leaf(Nesterov{Float32}(0.001, 0.9), Float32[-0.016, -0.088]), fun = nothing)
+
+julia> st = Optimisers.adjust(st, 0.123)  # change learning rate, stored momentum untouched
+(vec = Leaf(Nesterov{Float32}(0.123, 0.9), Float32[-0.016, -0.088]), fun = nothing)
+
+julia> Optimisers.adjust(st, Nesterov(0.10101, 0.90909))  # change both η and ρ
+(vec = Leaf(Nesterov{Float64}(0.10101, 0.90909), Float32[-0.016, -0.088]), fun = nothing)
+
+julia> Optimisers.adjust(st, Adam())  # this does nothing -- Adam stores two vectors
+┌ Warning: adjust did not find any rules to act on!
+└ @ Optimisers ~/.julia/dev/Optimisers/src/adjust.jl:33
+(vec = Leaf(Nesterov{Float32}(0.123, 0.9), Float32[-0.016, -0.088]), fun = nothing)
+```
+"""
+function adjust(tree, a)
+  ok = Ref(false)
+  newtree = _adjust(tree, a, ok)
+  ok[] || @warn "adjust did not find any rules to act on!"
+  newtree
+end
+
+# """
+#     Optimisers.adjust(tree; kw...) -> tree
+#
+# I'm not sure we want this keyword story, or not yet?
+# """
+# adjust(tree; kw...) = adjust(tree, NamedTuple(kw))
+
+_adjust(tree, a, ok::Ref) = map(st -> _adjust(st, a, ok), tree)
+_adjust(::Nothing, a, ok::Ref) = nothing
+function _adjust(ℓ::Leaf, a, ok::Ref)
+  newrule, flag = adjust(ℓ.rule, a)
+  ok[] |= flag
+  Leaf(newrule, ℓ.state)
+end
+
+"""
+    Optimisers.adjust(rule::RuleType, η::Real) -> rule, flag
+
+Replaces the learning rate of the optimisation rule with the given number.
+This method is only called by `adjust(tree, η)`, and if `RuleType` has a field
+called `:eta` and the default constructor, then the standard definition will work.
+It is only necessary to provide a method if your `struct` stores its learning rate
+in a different field.
+
+# Example
+```jldoctest
+julia> struct DecayDescent{T} <: Optimisers.AbstractRule  # as in the documentation
+         eta::T
+       end
+
+julia> Optimisers.adjust(DecayDescent(0.1f0), 0.23)  # works automatically
+(DecayDescent{Float32}(0.23f0), true)
+```
+"""
+function adjust(r::T, η::Real) where T <: AbstractRule
+  fs = fieldnames(T)
+  if :eta in fs
+    vals = map(fs) do field
+      field == :eta ? η : getfield(r, field)
+    end
+    T(vals...), true  # relies on having the default constructor
+  else
+    r, false
+  end
+end
+
+# adjust(r::AbstractRule, η::Real) = adjust(r, (eta = η,))
+# function adjust(r::T, nt::NamedTuple) where T <: AbstractRule
+#   fs = fieldnames(T)
+#   if all(k -> k in fs, keys(nt))
+#     vals = map(fs) do field
+#       get(nt, field, getfield(r, field))
+#     end
+#     T(vals...), true  # relies on having the default constructor
+#   else
+#     r, false
+#   end
+# end
+
+function adjust(oldr::AbstractRule, newr::AbstractRule)
+  if typeof(newr).name.wrapper == typeof(oldr).name.wrapper
+    newr, true
+  else
+    oldr, false
+  end
+end

--- a/src/adjust.jl
+++ b/src/adjust.jl
@@ -54,30 +54,8 @@ adjust(ℓ::Leaf; kw...) = Leaf(adjust(ℓ.rule; kw...), ℓ.state)
 """
     Optimisers.adjust(rule::RuleType, η::Real) -> rule
 
-Replaces the learning rate of the optimisation rule with the given number.
-
-This method is only called by `adjust(tree, η)`, and if `RuleType` has a field
-called `:eta` and the default constructor, then the standard definition will work.
-
-It should only be necessary to provide a method if your custom `struct` stores its
-learning rate a field with a different name. Or if an inner constructor blocks the
-default behaviour.
-
-# Example
-```jldoctest
-julia> Optimisers.adjust(Adam(), 0.12345)
-(Adam{Float32}(0.12345f0, (0.9f0, 0.999f0), 1.1920929f-7), true)
-
-julia> struct DecayDescent{T} <: Optimisers.AbstractRule  # as in the documentation
-         eta::T
-       end
-
-julia> Optimisers.adjust(DecayDescent(0.1f0), 0.2345)  # works automatically
-DecayDescent{Float32}(0.2345f0)
-
-julia> Optimisers.adjust(ClipNorm(), 0.345)  # does nothing, as this has no learning rate
-ClipNorm{Float32}(10.0f0, 2.0f0, true)
-```
+If a new optimisation rule has a learning rate which is *not* stored in field `rule.eta`,
+then you may should add a method to `adjust`. (But simpler to just use the standard name.)
 """
 adjust(r::AbstractRule, eta::Real) = _adjust(r, (; eta))
 adjust(r::AbstractRule; kw...) = _adjust(r, NamedTuple(kw))

--- a/src/adjust.jl
+++ b/src/adjust.jl
@@ -31,11 +31,11 @@ names of the optimisation rule's type.
 julia> fieldnames(Adam)
 (:eta, :beta, :epsilon)
 
-julia> st2 = Optimisers.setup(Adam(), m)
-(vec = Leaf(Adam{Float32}(0.001, (0.9, 0.999), 1.19209f-7), (Float32[0.0, 0.0], Float32[0.0, 0.0], (0.9, 0.999))), fun = nothing)
+julia> st2 = Optimisers.setup(OptimiserChain(ClipGrad(), Adam()), m)
+(vec = Leaf(OptimiserChain(ClipGrad{Float32}(10.0), Adam{Float32}(0.001, (0.9, 0.999), 1.19209f-7)), [nothing, (Float32[0.0, 0.0], Float32[0.0, 0.0], (0.9, 0.999))]), fun = nothing)
 
-julia> Optimisers.adjust(st2; beta = (0.777, 0.909))
-(vec = Leaf(Adam{Float32}(0.001, (0.777, 0.909), 1.19209f-7), (Float32[0.0, 0.0], Float32[0.0, 0.0], (0.9, 0.999))), fun = nothing)
+julia> Optimisers.adjust(st2; beta = (0.777, 0.909), delta = 11.1)  # delta acts on ClipGrad
+(vec = Leaf(OptimiserChain(ClipGrad{Float32}(11.1), Adam{Float32}(0.001, (0.777, 0.909), 1.19209f-7)), [nothing, (Float32[0.0, 0.0], Float32[0.0, 0.0], (0.9, 0.999))]), fun = nothing)
 
 julia> Optimisers.adjust(st; beta = "no such field")  # silently ignored!
 (vec = Leaf(Nesterov{Float32}(0.001, 0.9), Float32[-0.016, -0.088]), fun = nothing)

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -11,10 +11,9 @@ struct Leaf{R,S}
   state::S
 end
 
-function setup(rule, x; seen = rule isa Real ? () : Base.IdSet())
-  rule isa Union{Real, AbstractRule} || Base.depwarn("In future, all optimisation rules should be <: AbstractRule", :setup)
+function setup(rule, x; seen = Base.IdSet())
+  rule isa AbstractRule || Base.depwarn("In future, all optimisation rules should be <: AbstractRule", :setup)
   if isnumeric(x)
-    rule isa Real && throw(ArgumentError("setup(η, tree) expects a state tree, not a model"))
     x in seen && throw(ArgumentError("Optimisers.jl does not at present handle tied weights, sorry."))
     isbits(x) || push!(seen, x)
     return Leaf(rule, init(rule, x))
@@ -24,8 +23,6 @@ function setup(rule, x; seen = rule isa Real ? () : Base.IdSet())
     return map(xᵢ -> setup(rule, xᵢ; seen), _trainable(x))
   end
 end
-
-setup(a::Union{Real, AbstractRule}, ℓ::Leaf; seen = ()) = Leaf(adjust(ℓ.rule, a), ℓ.state)
 
 subtract!(x, x̄) = iswriteable(x) ? (x .= x .- x̄) : eltype(x).(x .- x̄)
 

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -24,6 +24,23 @@ function setup(rule, x; seen = Base.IdSet())
   end
 end
 
+adjust(rule::Union{Real, AbstractRule}, ℓ::Leaf) = Leaf(adjust(rule, ℓ.rule), ℓ.state)
+adjust(rule::Union{Real, AbstractRule}, ::Nothing) = nothing
+adjust(rule::Union{Real, AbstractRule}, tree) = map(st -> adjust(rule, st), tree)
+
+function adjust(newr::AbstractRule, r::AbstractRule)
+    typeof(newr).name.wrapper == typeof(r).name.wrapper || throw(ArgumentError("adjust(r′, r) expects the same rule with different parameters"))
+    newr
+end
+function adjust(η::Real, r::T) where T <: AbstractRule
+    fs = fieldnames(T)
+    :eta in fs || throw(ArgumentError("adjust(η, r) expects that optimisation rule store its learning rate in r.eta"))
+    vals = map(fs) do field
+        field == :eta ? η : getfield(r, field)
+    end
+    T(vals...)
+end
+
 subtract!(x, x̄) = iswriteable(x) ? (x .= x .- x̄) : eltype(x).(x .- x̄)
 
 update!(::Nothing, x, ::Zero, ::Zero...) = nothing, x

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -25,8 +25,7 @@ function setup(rule, x; seen = rule isa Real ? () : Base.IdSet())
   end
 end
 
-setup(rule::Union{Real, AbstractRule}, ℓ::Leaf; seen = ()) = Leaf(adjust(rule, ℓ.rule), ℓ.state)
-setup(rule::Union{Real, AbstractRule}, ::Nothing; seen = ()) = nothing
+setup(a::Union{Real, AbstractRule}, ℓ::Leaf; seen = ()) = Leaf(adjust(ℓ.rule, a), ℓ.state)
 
 subtract!(x, x̄) = iswriteable(x) ? (x .= x .- x̄) : eltype(x).(x .- x̄)
 

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -600,12 +600,12 @@ This is equivalent to `Descent(1)`.
 
 # Example
 ```jldoctest
-julia> o = OptimiserChain(ClipGrad(1), Descent(0.1));
+julia> o = OptimiserChain(ClipGrad(1.0), Descent(0.1));
 
 julia> m = (zeros(3),);
 
 julia> s = Optimisers.setup(o, m)
-(Leaf(OptimiserChain(ClipGrad{Int64}(1), Descent{Float64}(0.1)), [nothing, nothing]),)
+(Leaf(OptimiserChain(ClipGrad{Float64}(1.0), Descent{Float64}(0.1)), [nothing, nothing]),)
 
 julia> Optimisers.update(s, m, ([0.3, 1, 7],))[2]  # clips before discounting
 ([-0.03, -0.1, -0.1],)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -140,14 +140,14 @@ Optimisers.trainable(x::TwoThirds) = (a = x.a,)
       @test s1.γ.rule.eta == 0.1
       @test s1.γ.state ≈ [0.1, 1, 10]
   
-      s2 = Optimisers.setup(0.2, s1)
+      s2 = Optimisers.adjust(s1, 0.2)
       @test s2.γ.rule.eta == 0.2
       @test s2.γ.rule.rho == 0.9
       @test s2.γ.state == s1.γ.state
       @test s2.α[1].rule.eta == 0.2
       @test s2.α[1].state == s1.α[1].state
       
-      s3 = Optimisers.setup(Momentum(0.3, 0.7), s1)
+      s3 = Optimisers.adjust(s1, Momentum(0.3, 0.7))
       @test s3.γ.rule.eta == 0.3
       @test s3.γ.rule.rho == 0.7
       @test s3.γ.state == s1.γ.state
@@ -156,15 +156,16 @@ Optimisers.trainable(x::TwoThirds) = (a = x.a,)
       _, m3 = Optimisers.update(s3, m, (α = nothing, γ = [1,10,100],))
       @test !(m.γ .- m3.γ ≈ [1, 10, 100])
 
-      @test_throws ArgumentError Optimisers.setup(Nesterov(0.3, 0.7), s1)
-      
+      @info "ignore this warning, testing adjust with mismatched rules"
+      @test s1 == Optimisers.adjust(s1, Nesterov(0.3, 0.7))  # does nothing
+  
       # OptimiserChain
       sc = Optimisers.setup(OptimiserChain(ClipGrad(2), Adam()), m)
       sc1, mc1 = Optimisers.update(sc, m, (α = nothing, γ = [1,10,100],))
       @test sc1.γ.rule.opts[2].eta == 0.001f0
       @test sc1.γ.state[2][1] ≈ [0.1, 0.2, 0.2]
 
-      sc2 = Optimisers.setup(0.2, sc1)
+      sc2 = Optimisers.adjust(sc1, 0.2)
       @test sc2.γ.rule.opts[1].delta == 2 # unchanged
       @test sc2.γ.rule.opts[2].eta === 0.2f0
       @test sc2.γ.state[2][1] ≈ [0.1, 0.2, 0.2]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -130,6 +130,45 @@ Optimisers.trainable(x::TwoThirds) = (a = x.a,)
       @test eltype(m4[1]) == Float16  # because of explicit broadcast in subtract!
       @test eltype(m4[2]) == Float32
     end
+    
+    @testset "changing parameters" begin
+      # Simple momentum:
+      m = (α = ([0.0], sin), γ = Float32[4,3,2])
+      s = Optimisers.setup(Momentum(0.1, 0.9), m)
+      s1, m1 = Optimisers.update(s, m, (α = nothing, γ = [1,10,100],))
+      @test m.γ .- m1.γ ≈ [0.1, 1, 10]
+      @test s1.γ.rule.eta == 0.1
+      @test s1.γ.state ≈ [0.1, 1, 10]
+  
+      s2 = Optimisers.setup(0.2, s1)
+      @test s2.γ.rule.eta == 0.2
+      @test s2.γ.rule.rho == 0.9
+      @test s2.γ.state == s1.γ.state
+      @test s2.α[1].rule.eta == 0.2
+      @test s2.α[1].state == s1.α[1].state
+      
+      s3 = Optimisers.setup(Momentum(0.3, 0.7), s1)
+      @test s3.γ.rule.eta == 0.3
+      @test s3.γ.rule.rho == 0.7
+      @test s3.γ.state == s1.γ.state
+      @test s3.α[1].rule.rho == 0.7
+      
+      _, m3 = Optimisers.update(s3, m, (α = nothing, γ = [1,10,100],))
+      @test !(m.γ .- m3.γ ≈ [1, 10, 100])
+
+      @test_throws ArgumentError Optimisers.setup(Nesterov(0.3, 0.7), s1)
+      
+      # OptimiserChain
+      sc = Optimisers.setup(OptimiserChain(ClipGrad(2), Adam()), m)
+      sc1, mc1 = Optimisers.update(sc, m, (α = nothing, γ = [1,10,100],))
+      @test sc1.γ.rule.opts[2].eta == 0.001f0
+      @test sc1.γ.state[2][1] ≈ [0.1, 0.2, 0.2]
+
+      sc2 = Optimisers.setup(0.2, sc1)
+      @test sc2.γ.rule.opts[1].delta == 2 # unchanged
+      @test sc2.γ.rule.opts[2].eta === 0.2f0
+      @test sc2.γ.state[2][1] ≈ [0.1, 0.2, 0.2]
+    end
 
     @testset "forgotten gradient" begin
       x = [1.0, 2.0]


### PR DESCRIPTION
Closes #88, by adding making `setup(Adam(), state)` and `setup(0.02, state)` re-build the state tree with different parameters. This would have been trivial before #30 changed `update!(o, state, x, x̄)` to `update!(tree, x, x̄)`.

Right now the new `adjust` is like `init`, acts on one thing, while `setup` & `update` act on the whole model/tree. Could avoid the name by making them callable, like `Adam()(0.02)`, which perhaps some earlier version had. 

At the moment many things are errors, such as mismatched optimisers, and rules without a field `:eta` to change. It's possible that they should instead do nothing, so that only some leaves are changed, others left alone.

Could easily be generalised to say `setup(state; eta=0.02)` allowing you to set any field of all rules. If desired.