### PR TITLE
Transparent handling of tied weights

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 ChainRulesCore = "1"
-Functors = "0.2.8, 0.3"
+Functors = "0.3"
 Zygote = "0.6.40"
 julia = "1.6"
 


### PR DESCRIPTION
This makes `Leaf` a mutable type so that tied weights are represented by the same leaf instance.

Although only mutable array types are automatically detected as tied, one can also tie immutable parameters by manually creating shared `Leaf`s.

The test suite is practically the same as #42, with some slight modifications since there is no equivalent to `Tied` in this PR.