### PR TITLE
Allow shared parameters, take III

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Optimisers"
 uuid = "3bd65402-5787-11e9-1adc-39752487f4e2"
 authors = ["Mike J Innes <mike.j.innes@gmail.com>"]
-version = "0.2.9"
+version = "0.2.10"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
@@ -12,7 +12,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 ChainRulesCore = "1"
-Functors = "0.2.8, 0.3"
+Functors = "0.3"
 Zygote = "0.6.40"
 julia = "1.6"
 

--- a/src/Optimisers.jl
+++ b/src/Optimisers.jl
@@ -1,6 +1,6 @@
 module Optimisers
 
-using Functors: functor, fmap, isleaf
+using Functors: functor, fmap, isleaf, @functor, fmapstructure, children
 using LinearAlgebra
 
 include("interface.jl")
@@ -157,8 +157,8 @@ true
 julia> m  # original should be discarded, may be mutated but no guarantee
 (x = Float32[0.6666666, 1.5333333], y = Float32[4.0, 5.0])
 
-julia> t  # original state should likewise be discarded
-(x = Leaf(Momentum{Float64}(0.0333333, 0.9), Float32[0.333333, 0.466667]), y = Leaf(Momentum{Float64}(0.0333333, 0.9), Float32[0.0, 0.0]))
+julia> t == t2  # original state is in fact guaranteed to be mutated
+true
 ```
 """
 update!

--- a/src/Optimisers.jl
+++ b/src/Optimisers.jl
@@ -77,7 +77,7 @@ or [`update!`](@ref).
 julia> m = (x = rand(3), y = (true, false), z = tanh);
 
 julia> Optimisers.setup(Momentum(), m)  # same field names as m
-(x = Leaf(Momentum{Float32}(0.01, 0.9), [0.0, 0.0, 0.0]), y = (nothing, nothing), z = nothing)
+(x = Leaf(Momentum{Float32}(0.01, 0.9), [0.0, 0.0, 0.0]), y = ((), ()), z = ())
 ```
 
 The recursion into structures uses Functors.jl, and any new `struct`s containing parameters
@@ -90,7 +90,7 @@ julia> struct Layer; mat; fun; end
 julia> model = (lay = Layer([1 2; 3 4f0], sin), vec = [5, 6f0]);
 
 julia> Optimisers.setup(Momentum(), model)  # new struct is by default ignored
-(lay = nothing, vec = Leaf(Momentum{Float32}(0.01, 0.9), Float32[0.0, 0.0]))
+(lay = (), vec = Leaf(Momentum{Float32}(0.01, 0.9), Float32[0.0, 0.0]))
 
 julia> destructure(model)
 (Float32[5.0, 6.0], Restructure(NamedTuple, ..., 2))
@@ -98,7 +98,7 @@ julia> destructure(model)
 julia> using Functors; @functor Layer  # annotate this type as containing parameters
 
 julia> Optimisers.setup(Momentum(), model)
-(lay = (mat = Leaf(Momentum{Float32}(0.01, 0.9), Float32[0.0 0.0; 0.0 0.0]), fun = nothing), vec = Leaf(Momentum{Float32}(0.01, 0.9), Float32[0.0, 0.0]))
+(lay = (mat = Leaf(Momentum{Float32}(0.01, 0.9), Float32[0.0 0.0; 0.0 0.0]), fun = ()), vec = Leaf(Momentum{Float32}(0.01, 0.9), Float32[0.0, 0.0]))
 
 julia> destructure(model)
 (Float32[1.0, 3.0, 2.0, 4.0, 5.0, 6.0], Restructure(NamedTuple, ..., 6))
@@ -120,12 +120,12 @@ See also [`update!`](@ref), which will be faster for models of ordinary `Array`s
 julia> m = (x = Float32[1,2,3], y = tanh);
 
 julia> t = Optimisers.setup(Descent(0.1f0), m)
-(x = Leaf(Descent{Float32}(0.1), nothing), y = nothing)
+(x = Leaf(Descent{Float32}(0.1), nothing), y = ())
 
 julia> g = (x = [1,1,1], y = nothing);  # fake gradient
 
 julia> Optimisers.update(t, m, g)
-((x = Leaf(Descent{Float32}(0.1), nothing), y = nothing), (x = Float32[0.9, 1.9, 2.9], y = tanh))
+((x = Leaf(Descent{Float32}(0.1), nothing), y = ()), (x = Float32[0.9, 1.9, 2.9], y = tanh))
 ```
 """
 update

--- a/src/Optimisers.jl
+++ b/src/Optimisers.jl
@@ -16,6 +16,10 @@ export Descent, Adam, Momentum, Nesterov, Rprop, RMSProp,
        AdaGrad, AdaMax, AdaDelta, AMSGrad, NAdam, AdamW, RAdam, OAdam, AdaBelief,
        WeightDecay, ClipGrad, ClipNorm, OptimiserChain
 
+###
+### one-array functions
+###
+
 """
     Optimisers.apply!(rule::RuleType, state, parameters, gradient) -> (state, gradient)
 
@@ -56,6 +60,10 @@ julia> Optimisers.init(Momentum(), [1.0, 2.0])
 ```
 """
 init
+
+###
+### whole-model functions
+###
 
 """
     Optimisers.setup(rule, model) -> tree

--- a/src/adjust.jl
+++ b/src/adjust.jl
@@ -13,15 +13,15 @@ To change just the learning rate, provide a number `η::Real`.
 julia> m = (vec = rand(Float32, 2), fun = sin);
 
 julia> st = Optimisers.setup(Nesterov(), m)  # stored momentum is initialised to zero
-(vec = Leaf(Nesterov{Float32}(0.001, 0.9), Float32[0.0, 0.0]), fun = nothing)
+(vec = Leaf(Nesterov{Float32}(0.001, 0.9), Float32[0.0, 0.0]), fun = ())
 
 julia> st, m = Optimisers.update(st, m, (vec = [16, 88], fun = nothing));  # with fake gradient
 
 julia> st
-(vec = Leaf(Nesterov{Float32}(0.001, 0.9), Float32[-0.016, -0.088]), fun = nothing)
+(vec = Leaf(Nesterov{Float32}(0.001, 0.9), Float32[-0.016, -0.088]), fun = ())
 
 julia> st = Optimisers.adjust(st, 0.123)  # change learning rate, stored momentum untouched
-(vec = Leaf(Nesterov{Float32}(0.123, 0.9), Float32[-0.016, -0.088]), fun = nothing)
+(vec = Leaf(Nesterov{Float32}(0.123, 0.9), Float32[-0.016, -0.088]), fun = ())
 ```
 
 To change other parameters, `adjust` also accepts keyword arguments matching the field

--- a/src/adjust.jl
+++ b/src/adjust.jl
@@ -47,8 +47,8 @@ adjust(tree; kw...) = map(st -> adjust(st; kw...), tree)
 adjust(::Nothing, ::Real) = nothing
 adjust(::Nothing; kw...) = nothing
 
-adjust(ℓ::Leaf, eta::Real) = ℓ.frozen ? ℓ : Leaf(adjust(ℓ.rule, eta), ℓ.state, ℓ.frozen)
-adjust(ℓ::Leaf; kw...) = ℓ.frozen ? ℓ : Leaf(adjust(ℓ.rule; kw...), ℓ.state, ℓ.frozen)
+adjust(ℓ::Leaf, eta::Real) = Leaf(adjust(ℓ.rule, eta), ℓ.state)
+adjust(ℓ::Leaf; kw...) = Leaf(adjust(ℓ.rule; kw...), ℓ.state)
 
 
 """

--- a/src/adjust.jl
+++ b/src/adjust.jl
@@ -47,8 +47,8 @@ adjust(tree; kw...) = map(st -> adjust(st; kw...), tree)
 adjust(::Nothing, ::Real) = nothing
 adjust(::Nothing; kw...) = nothing
 
-adjust(ℓ::Leaf, eta::Real) = Leaf(adjust(ℓ.rule, eta), ℓ.state)
-adjust(ℓ::Leaf; kw...) = Leaf(adjust(ℓ.rule; kw...), ℓ.state)
+adjust(ℓ::Leaf, eta::Real) = ℓ.frozen ? ℓ : Leaf(adjust(ℓ.rule, eta), ℓ.state, ℓ.frozen)
+adjust(ℓ::Leaf; kw...) = ℓ.frozen ? ℓ : Leaf(adjust(ℓ.rule; kw...), ℓ.state, ℓ.frozen)
 
 
 """

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -60,8 +60,8 @@ subtract!(x, x̄) = maywrite(x) ? (x .= x .- x̄) : eltype(x).(x .- x̄)
 
 grads!(dict::IdDict, ℓ::Leaf, x, ::Zero) = nothing
 function grads!(dict::IdDict, ℓ::Leaf, x, x̄)
-  x̄₀ = get(dict, ℓ, false)
-  dict[ℓ] = Broadcast.broadcasted(+, x̄, x̄₀)
+  x̄₀ = get(dict, ℓ, ZeroTangent())
+  dict[ℓ] = x̄ + x̄₀  # adding Zero should be free. Lazy accumulation broadcasted(+, x̄, x̄₀) also possible.
   nothing
 end
 grads!(dict::IdDict, t, x, ::Zero) = nothing

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -74,8 +74,12 @@ function _update!(tree, x; grads, params)
   haskey(params, (tree,x)) && return params[(tree,x)]
   isbits(tree) && return x  # means () is not cached, and also (((),),)
   x′, re = functor(x)
-  x′′ = map((tᵢ, xᵢ) -> _update!(tᵢ, xᵢ; grads, params), tree, x′)
-  params[(tree,x)] = re(x′′)
+  x′′ = re(map((tᵢ, xᵢ) -> _update!(tᵢ, xᵢ; grads, params), tree, x′))
+  if ismutable(x′′)
+    params[(tree,x)] = x′′
+  else  # no ties to preserve between immutable structs, right?
+    x′′
+  end
 end
 function _update!(ℓ::Leaf, x; grads, params)
   haskey(params, (ℓ,x)) && return params[(ℓ,x)]

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -166,7 +166,7 @@ end
 ###
 
 """
-    @.. x = x + y
+    @.. x = y + z
 
 Sometimes in-place broadcasting macro, for use in `apply!` rules.
 If `maywrite(x)` then it is just `@. x = rhs`, but if not, it becomes `x = @. rhs`.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -48,6 +48,17 @@ end
       g4 = Tangent{typeof(m)}(g...)
       s4, m4 = Optimisers.update!(s, ([1.0, 2.0],), g4)
       @test m4[1] ≈ [1,2] .- 0.1 .* [25, 33]
+      
+      o5 = Momentum(0.1)
+      s5 = Optimisers.setup(o5, m)
+      
+      s6, m6 = Optimisers.update(s5, m, g)
+      @test s6[1].state ≈ [2.5, 3.3]
+      @test s5[1].state == [0, 0]  # not mutated -- wrong on v0.2.9
+
+      s7, m7 = Optimisers.update!(s5, m, g)
+      @test s7[1].state === s5[1].state  # same array
+      @test s7[1] === s5[1]  # same Leaf
     end
 
     @testset "gradient clipping" begin
@@ -225,12 +236,75 @@ end
     end
 
     @testset "tied weights" begin
-      ok = (1.0:3.0, sin, "abc", :abc)
-      m = (α = ok, β = rand(3), γ = ok)
-      m1 = (rand(3), m, rand(3))
-      @test Optimisers.setup(AdamW(), m1) isa Tuple
-      m2 = (rand(3), m, rand(3), m, rand(3))  # illegal
-      @test_throws ArgumentError Optimisers.setup(AdamW(), m2)
+      @testset "tuples" begin
+         twice = [1,2.0]
+         mtup = (twice, (copy(twice), twice)) # (tied (not tied, tied))
+
+         # simplest rule for which opt(g1) + opt(g2) != opt(g1 + g2)
+         stup = Optimisers.setup(Momentum(0.1), mtup)
+         gtup = ([3,3], ([10,10], [7,7])) # (g1, (g1 + g2, g2))
+
+         snew, mnew = Optimisers.update(stup, mtup, gtup)
+         @test mnew[1] ≈ mnew[2][1]  # gradient was accumulated
+         @test mnew[2][2] === mnew[1]  # and tie is not broken
+
+         st3, mt3 = Optimisers.update(stup, mtup, ([3,3], nothing))
+         @test mt3[1] ≈ [1,2] - 0.1 * [3,3]
+         @test mt3[2][2] === mt3[1]
+
+         st4, mt4 = Optimisers.update(stup, mtup, (nothing, ([5,5], [7,7])))
+         @test mt4[1] ≈ [1,2] - 0.1 * [7,7]
+       end
+
+       @testset "named" begin
+         thrice = [3f0]
+         model = (a = (x = thrice, y = Float32[4,5,6], z = true), b = ((m = (0, 1, thrice),),), c = (x = Float32[7,8], y = thrice))
+         tree = Optimisers.setup(Momentum(0.1, 0.9), model)
+         @test model.a.x === model.b[1].m[3] == model.c.y
+
+         loss(x::Array) = sum(abs2, x)
+         loss(x::Number) = x^3
+         loss(m) = sum(2 * loss(x) for x in m)
+         gradient(loss, model)
+         _, m2 = Optimisers.update(tree, model, gradient(loss, model)...)
+         @test m2.a.x === m2.b[1].m[3] == m2.c.y
+
+         loss3(m) = sum(x isa Tuple ? 0 : 2 * loss(x) for x in m)
+         gradient(loss3, model)  # truncates the b limb
+         _, m3 = Optimisers.update(tree, model, gradient(loss3, model)...)
+         @test m3.a.x === m3.b[1].m[3] == m3.c.y
+       end
+
+       @testset "transpose" begin
+         mat = [1 2 3; 4 5 6.0]
+         bidir = (m = mat, f = log, t = transpose(mat), v = [7, 8, 9.0])
+         bigrad, _ = gradient((m, x) -> sum(abs2, m.m * (m.f).(m.t*x .+ m.v)), bidir, [1, 0.1])
+         @test bigrad.t isa Matrix  # not a Transpose, that's the point here
+
+         state = Optimisers.setup(Descent(0.1), bidir)
+         @test state.t.parent === state.m  # successfully tied
+
+         s2, b2 = Optimisers.update(state, bidir, bigrad)
+         @test b2.t.parent === b2.m  # tie restored
+         @test b2.m ≈ bidir.m - 0.1 * (bigrad.m + transpose(bigrad.t))  # grad accumulated
+
+         state = Optimisers.setup(OptimiserChain(ClipGrad(10), Descent(0.1), ClipGrad(10)), bidir)
+         s2, b2 = Optimisers.update(state, bidir, bigrad)
+         @test b2.t.parent === b2.m
+         @test b2.m ≈ bidir.m - 0.1 * clamp.((bigrad.m + transpose(bigrad.t)), -10, 10)
+
+         # Similar, but now "primary" field is the transposed one:
+         tri = (a = transpose(mat), b = mat, c = transpose(mat), d = 4.0)
+         trigrad = gradient(m -> sum(abs2, m.a * (m.b * (m.c * [0.1, 1] .+ m.d) .- m.d)), tri)[1]
+         stri = Optimisers.setup(Descent(0.1), tri)
+         s3, t3 = Optimisers.update(stri, tri, trigrad)
+         @test t3.a.parent === t3.b === t3.c.parent
+         @test t3.a ≈ tri.a - 0.1 * (trigrad.a + trigrad.b' + trigrad.c)
+
+         g4 = (a = Broadcast.broadcasted(+, mat', 1), b = nothing, c = @thunk(mat' .+ 1), d = nothing)
+         # Error: no constructors for type Any
+         @test_broken s4, t4 = Optimisers.update(stri, tri, g4)
+       end
     end
 
     @testset "higher order interface" begin


### PR DESCRIPTION
Another take on #100. Borrows the idea of making `Leaf` mutable.

~~Tries~~Tried to be simpler by pushing more of the recursion onto `fmap`:
* `setup` is just `fmapstructure` really. Its notion of sharing is thus exactly the one of Functors, one source of truth. We should fix that not to share `isbits` types, eventually.
* `update!` is just `fmap`. Much of the complication of the old walk was to reconstruct both the state and the model on the way out. But this isn't needed if Leaf is mutated. 

Tests from #100 pass with first commit. However, the shared Leaves must always match shared Arrays. It's possible that this scenario can be done even more simply, possibly without mutable Leaf. 

What #100 does is instead to take shared Leaves as the truth about parameter sharing, which some future API could set in a way not matching the model (for ImmutableArrays, etc) even though present `setup` will not. Then `update!` cannot just be `fmap`, and needs one more separate `IdDict` for the parameters. Second commit here  e84b61b bolts that on, and adds a test of it (which also pass using https://github.com/FluxML/Optimisers.jl/pull/100). But it's a bit ugly.

Edit: Third commit 0de29e1 instead just replaces the walk used for `fmap(f, tree, x)` to use `re` from its 2nd argument, while Functors still uses the cache on the 1st argument. That's tidier.

But the state tree contains the the same `()` at every non-parameter node, and Functors caches the results of these... we should fix this upstream? A possible hack for now would be to supply a special cache `IdDict{Leaf}` which cannot store anything else -- done in e17e474.

But... that's still not right. If there are mutable layer structs, then I think you cannot rely on the ID of mutable `Leaf` to tie things. So I gave up on customising `fmap` and wrote out the recursion using `(x,Leaf())` as the key for reconstruction.

---

Gradient accumulation uses an IdDict as in #100, but ~~stores a `broadcasted` adding the pieces. Which it thus requires all `apply!` methods to accept. They all do.~~ Changed to eager addition.

~~Does not at present allow for more than one derivative. But no rules use that.~~ Added. There were no tests it seems.

Fixes the bug noted in #100 that `update` could in fact mutate the state. Does this by just saying `@functor Leaf`. Added a test.

One further possibility with a mutable `Leaf` is that if can easily have a flag to mark some parameters as temporarily frozen. ~~This is implemented here (with no API to set the flag). Not sure it's what we want though. Easy to remove but perhaps if we're changing the struct we should consider other changes we might want.~~

Because `setup` does not call itself in recursion, it is fairly easy to add a warning if the model has no parameters. This was something someone complained about, I forget where.

---

Closes https://github.com/FluxML/Optimisers.jl/pull/42, closes #100, closes #97