### PR TITLE
Add `freeze!`/`thaw!`

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -35,6 +35,8 @@ Optimisers.setup
 Optimisers.update
 Optimisers.update!
 Optimisers.adjust(::Any, ::Real)
+Optimisers.freeze!
+Optimisers.thaw!
 ```
 
 Calling `Functors.@functor` on your model's layer types by default causes

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -155,13 +155,14 @@ opt = Optimisers.setup(Optimisers.Momentum(), net);
 
 net.layers[3] isa Dense  # now freeze this layer's parameters:
 Optimisers.freeze!(opt.layers[3])
+opt.layers[3].bias  # confirm: Leaf(Momentum(...), [0.0, 0.0], frozen = true)
 
 Optimisers.update!(opt, net, gradient(m -> sum(m(x)), net)...);
 
-net.layers[3].bias  # stil zero, and its momentum is zero too:
-opt  # bias = Leaf(Momentum{Float32}(0.01, 0.9), Float32[0.0, 0.0], frozen = true)
+net.layers[3].bias  # stil zero, and its momentum is too:
 
 Optimisers.thaw!(opt)
+opt.layers[3].bias  # Leaf(Momentum(...), [0.0, 0.0])
 ```
 
 ## Tied Parameters

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -142,7 +142,7 @@ st = Optimisers.setup(DecayDescent(0.1), Layer(3))
 
 To temporarily prevent training from affecting some parameters,
 use [freeze!](@ref Optimisers.freeze!) and `thaw!`.
-They work by mutating all `Leaf`s of the state tree, within the given limb:
+They work by mutating all `Leaf`s of the state tree, or part of it.
 
 ```julia
 using Flux, Optimisers
@@ -158,6 +158,7 @@ Optimisers.freeze!(opt.layers[3])
 
 Optimisers.update!(opt, net, gradient(m -> sum(m(x)), net)...);
 
+net.layers[3].bias  # stil zero, and its momentum is zero too:
 opt  # bias = Leaf(Momentum{Float32}(0.01, 0.9), Float32[0.0, 0.0], frozen = true)
 
 Optimisers.thaw!(opt)

--- a/src/adjust.jl
+++ b/src/adjust.jl
@@ -28,7 +28,7 @@ julia> m
 (x = ([1.0], 2.0), y = [-0.14159258336972558])
 
 julia> s
-(x = (Leaf(Momentum{Float32}(0.01, 0.9), [0.0], frozen=true), ()), y = Leaf(Momentum{Float32}(0.01, 0.9), [3.14159]))
+(x = (Leaf(Momentum{Float32}(0.01, 0.9), [0.0], frozen = true), ()), y = Leaf(Momentum{Float32}(0.01, 0.9), [3.14159]))
 
 julia> Optimisers.thaw!(s)
 

--- a/src/adjust.jl
+++ b/src/adjust.jl
@@ -12,6 +12,8 @@ Can be applied to the state corresponding to only part of a model,
 for instance with `model::Chain`, to freeze `model.layers[1]` you
 should call `freeze!(tree.layers[1])`.
 
+Also prevents [`adjust`](@ref Optimisers.adjust) from changing the rule's parameters.
+
 # Example
 ```jldoctest
 julia> m = (x = ([1.0], 2.0), y = [3.0]);
@@ -64,6 +66,8 @@ through training.
 
 To change just the learning rate, provide a number `η::Real`.
 
+Does not affect any frozen parameters, set by [`freeze!`](@ref Optimisers.freeze!).
+
 # Example
 ```jldoctest
 julia> m = (vec = rand(Float32, 2), fun = sin);
@@ -103,8 +107,8 @@ adjust(tree; kw...) = map(st -> adjust(st; kw...), tree)
 adjust(::Nothing, ::Real) = nothing
 adjust(::Nothing; kw...) = nothing
 
-adjust(ℓ::Leaf, eta::Real) = Leaf(adjust(ℓ.rule, eta), ℓ.state)
-adjust(ℓ::Leaf; kw...) = Leaf(adjust(ℓ.rule; kw...), ℓ.state)
+adjust(ℓ::Leaf, eta::Real) = ℓ.frozen ? ℓ : Leaf(adjust(ℓ.rule, eta), ℓ.state)
+adjust(ℓ::Leaf; kw...) = ℓ.frozen ? ℓ : Leaf(adjust(ℓ.rule; kw...), ℓ.state)
 
 
 """

--- a/src/adjust.jl
+++ b/src/adjust.jl
@@ -22,13 +22,13 @@ julia> Optimisers.update!(s, m, (x = ([pi], 10pi), y = [100pi]));  # with fake g
 julia> m
 (x = ([1.0], 2.0), y = [-0.14159258336972558])
 
-julia> s  # Leaf(..., true) means frozen
-(x = (Leaf(Momentum{Float32}(0.01, 0.9), [0.0], true), ()), y = Leaf(Momentum{Float32}(0.01, 0.9), [3.14159]))
+julia> s
+(x = (Leaf(Momentum{Float32}(0.01, 0.9), [0.0], frozen=true), ()), y = Leaf(Momentum{Float32}(0.01, 0.9), [3.14159]))
 
 julia> Optimisers.thaw!(s)
 
-julia> s.x[1]
-Leaf(Momentum{Float32}(0.01, 0.9), [0.0])
+julia> s.x
+(Leaf(Momentum{Float32}(0.01, 0.9), [0.0]), ())
 ```
 """
 freeze!(tree) = (fmapstructure(freeze!, tree; exclude = x -> x isa Leaf); nothing)

--- a/src/adjust.jl
+++ b/src/adjust.jl
@@ -1,5 +1,5 @@
 ###
-### freeze!
+### freezing
 ###
 
 """
@@ -11,8 +11,6 @@ will not be updated. Un-done by [`thaw!`](@ref Optimisers.thaw!).
 Can be applied to the state corresponding to only part of a model,
 for instance with `model::Chain`, to freeze `model.layers[1]` you
 should call `freeze!(tree.layers[1])`.
-
-Also prevents [`adjust`](@ref Optimisers.adjust) from changing the rule's parameters.
 
 # Example
 ```jldoctest
@@ -66,8 +64,6 @@ through training.
 
 To change just the learning rate, provide a number `η::Real`.
 
-Does not affect any frozen parameters, set by [`freeze!`](@ref Optimisers.freeze!).
-
 # Example
 ```jldoctest
 julia> m = (vec = rand(Float32, 2), fun = sin);
@@ -107,8 +103,8 @@ adjust(tree; kw...) = map(st -> adjust(st; kw...), tree)
 adjust(::Nothing, ::Real) = nothing
 adjust(::Nothing; kw...) = nothing
 
-adjust(ℓ::Leaf, eta::Real) = ℓ.frozen ? ℓ : Leaf(adjust(ℓ.rule, eta), ℓ.state)
-adjust(ℓ::Leaf; kw...) = ℓ.frozen ? ℓ : Leaf(adjust(ℓ.rule; kw...), ℓ.state)
+adjust(ℓ::Leaf, eta::Real) = Leaf(adjust(ℓ.rule, eta), ℓ.state, ℓ.frozen)
+adjust(ℓ::Leaf; kw...) = Leaf(adjust(ℓ.rule; kw...), ℓ.state, ℓ.frozen)
 
 
 """

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -49,7 +49,7 @@ function Base.show(io::IO, ℓ::Leaf; colour = ℓ.frozen ? :cyan : :green)
   str = sprint(show, ℓ.rule; context = ioc)
   printstyled(io, "Leaf(", str, ", "; color = colour)
   show(ioc, ℓ.state)
-  printstyled(io, ℓ.frozen ? ", frozen=true)" : ")"; color = colour)
+  printstyled(io, ℓ.frozen ? ", frozen = true)" : ")"; color = colour)
 end
 
 ###

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -46,7 +46,7 @@ end
 
 function Base.show(io::IO, ℓ::Leaf; colour = ℓ.frozen ? :cyan : :green)
   ioc = IOContext(io, :compact => true)
-  str = sprint(show, ℓ.rule; context = ioc)
+  str = sprint(show, ℓ.rule; context = ioc)  # produces Adam{Float32}(0.001, ... not 0.001f0
   printstyled(io, "Leaf(", str, ", "; color = colour)
   show(ioc, ℓ.state)
   printstyled(io, ℓ.frozen ? ", frozen = true)" : ")"; color = colour)

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -15,7 +15,7 @@ mutable struct Leaf{R,S}  # mutable so that its identity encodes parameter shari
   state::S
   frozen::Bool  # ... and to allow freeze! to act on this.
 end
-Leaf(rule, state) = Leaf(rule, state, false)
+Leaf(rule, state; frozen::Bool = false) = Leaf(rule, state, frozen)
 
 @functor Leaf
 
@@ -44,12 +44,12 @@ function _setup(rule, x; cache)
   end
 end
 
-function Base.show(io::IO, ℓ::Leaf)  # show method is mostly to hide its long type!
+function Base.show(io::IO, ℓ::Leaf; colour = ℓ.frozen ? :cyan : :green)
   ioc = IOContext(io, :compact => true)
-  print(ioc, "Leaf(", ℓ.rule, ", ")
+  str = sprint(show, ℓ.rule; context = ioc)
+  printstyled(io, "Leaf(", str, ", "; color = colour)
   show(ioc, ℓ.state)
-  ℓ.frozen && print(ioc, ", true")
-  print(ioc, ")")
+  printstyled(io, ℓ.frozen ? ", frozen=true)" : ")"; color = colour)
 end
 
 ###

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -232,7 +232,7 @@ end
       st = Optimisers.adjust(st, 0.2)
       Optimisers.thaw!(st)
       st, m = Optimisers.update(st, m, (x=[1,10], y=([100,1000], nothing)));
-      @test m.y[1] ≈ [-7.0, -96.0]
+      @test m.y[1] ≈ [-17.0, -196.0]
       @test m.x ≈ [0.7, -1.0]
 
       @test_throws ArgumentError Optimisers.freeze!(m)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -221,6 +221,24 @@ end
       @test sc2.γ.state[2][1] ≈ [0.1, 0.2, 0.2]
     end
 
+    @testset "freeze/thaw" begin
+      m = (x=[1.0, 2.0], y=([3.0, 4.0], sin));
+      st = Optimisers.setup(Descent(0.1), m);
+      Optimisers.freeze!(st.y)
+      st, m = Optimisers.update(st, m, (x=[1,10], y=([100,1000], nothing)));
+      @test m.x ≈ [0.9, 1.0]
+      @test m.y[1] == [3, 4]
+
+      st = Optimisers.adjust(st, 0.2)
+      Optimisers.thaw!(st)
+      st, m = Optimisers.update(st, m, (x=[1,10], y=([100,1000], nothing)));
+      @test m.y[1] ≈ [-7.0, -96.0]
+      @test m.x ≈ [0.7, -1.0]
+
+      @test_throws ArgumentError Optimisers.freeze!(m)
+      @test_throws ArgumentError Optimisers.thaw!(m)
+    end
+
     @testset "forgotten gradient" begin
       x = [1.0, 2.0]
       sx = Optimisers.setup(Descent(), x)


### PR DESCRIPTION
Replaces #49 with something much simpler: now that `Leaf` is mutable, you can simply pass it the appropriate limb of the state tree, rather than having some explicit address mechanism.

Addresses some of #107

### PR Checklist

- [x] Tests are added
- [x] Documentation, if applicable
