### PR TITLE
Add `adjust!`

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -34,6 +34,7 @@ Optimisers.OptimiserChain
 Optimisers.setup
 Optimisers.update
 Optimisers.update!
+Optimisers.adjust!
 Optimisers.adjust(::Any, ::Real)
 Optimisers.freeze!
 Optimisers.thaw!

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -165,7 +165,7 @@ Optimisers.thaw!(opt)
 opt.layers[3].bias  # Leaf(Momentum(...), [0.0, 0.0])
 ```
 
-## Adjusting Learning Rate
+## Adjusting Hyperparameters
 
 To change the learning rate during training, use [`adjust!`](@ref Optimisers.adjust!).
 This works much like `freeze!` by mutating the state tree, or part of it,

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -165,6 +165,26 @@ Optimisers.thaw!(opt)
 opt.layers[3].bias  # Leaf(Momentum(...), [0.0, 0.0])
 ```
 
+## Adjusting Learning Rate
+
+To change the learning rate during training, use [`adjust!`](@ref Optimisers.adjust!).
+This works much like `freeze!` by mutating the state tree, or part of it,
+without discarding the momenta. For the Flux model from just above:
+
+```julia
+Optimisers.adjust!(opt, 0.03)  # change η for the whole model...
+
+Optimisers.adjust!(opt.layers[3], 0.04)  # ... or just for one layer.
+```
+
+To change other fields of the optimisation rule, it accepts keyword arguments:
+
+```julia
+Momentum |> fieldnames  # (:eta, :rho)
+
+Optimisers.adjust!(opt, rho = 0.95)  # change ρ for the whole model.
+```
+
 ## Tied Parameters
 
 If the same array appears twice (or more) in the model, [Functors.jl](https://fluxml.ai/Functors.jl) should recognise this.
@@ -187,7 +207,7 @@ This identification relies on `===`, and will work for ordinary `Array`s and `Cu
 It will not at present work for `reshape`d arrays, nor for immutable arrays such as those
 from StaticArrays.jl.
 
- 
+
 ## Obtaining a flat parameter vector
 
 Instead of a nested tree-like structure, sometimes is is convenient to have all the

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -177,7 +177,7 @@ end
       @test eltype(s6[2].state[2]) == Float32
     end
 
-    @testset "adjusyting parameters, 1" begin
+    @testset "adjusting parameters, out-of-place" begin
       # Simple momentum:
       m = (α = ([0.0], sin), γ = Float32[4,3,2])
       s = Optimisers.setup(Momentum(0.1, 0.9), m)
@@ -221,7 +221,7 @@ end
       @test sc2.γ.state[2][1] ≈ [0.1, 0.2, 0.2]
     end
 
-    @testset "adjusyting parameters, 2!" begin  # Same tests, just in-place
+    @testset "adjusting parameters, in-place" begin
       # Simple momentum:
       m = (α = ([0.0], sin), γ = Float32[4,3,2])
       s = Optimisers.setup(Momentum(0.1, 0.9), m)


### PR DESCRIPTION
Now that `Leaf` is mutable, perhaps it is useful to be able to change `eta` only for some parts of the model.

PR also solves the following bug: `adjust` doesn't copy the momenta, and thus they remain shared with the previous object. 

### PR Checklist

- [x] Tests are added
- [x] Documentation, if applicable
