### PR TITLE
Mark `OptimiserChain` as `@functor` and improve inference for `apply!`

### DIFF
--- a/src/adjust.jl
+++ b/src/adjust.jl
@@ -9,7 +9,7 @@ through training.
 To change just the learning rate, provide a number `η::Real`.
 
 # Example
-```jldoctest
+```jldoctest adjust
 julia> m = (vec = rand(Float32, 2), fun = sin);
 
 julia> st = Optimisers.setup(Nesterov(), m)  # stored momentum is initialised to zero
@@ -27,7 +27,7 @@ julia> st = Optimisers.adjust(st, 0.123)  # change learning rate, stored momentu
 To change other parameters, `adjust` also accepts keyword arguments matching the field
 names of the optimisation rule's type.
 
-```
+```jldoctest adjust
 julia> fieldnames(Adam)
 (:eta, :beta, :epsilon)
 
@@ -38,7 +38,7 @@ julia> Optimisers.adjust(st2; beta = (0.777, 0.909), delta = 11.1)  # delta acts
 (vec = Leaf(OptimiserChain(ClipGrad{Float32}(11.1), Adam{Float32}(0.001, (0.777, 0.909), 1.19209f-7)), (nothing, (Float32[0.0, 0.0], Float32[0.0, 0.0], (0.9, 0.999)))), fun = ())
 
 julia> Optimisers.adjust(st; beta = "no such field")  # silently ignored!
-(vec = Leaf(Nesterov{Float32}(0.001, 0.9), Float32[-0.016, -0.088]), fun = ())
+(vec = Leaf(Nesterov{Float32}(0.123, 0.9), Float32[-0.016, -0.088]), fun = ())
 ```
 """
 adjust(tree, eta::Real) = map(st -> adjust(st, eta), tree)

--- a/src/adjust.jl
+++ b/src/adjust.jl
@@ -32,13 +32,13 @@ julia> fieldnames(Adam)
 (:eta, :beta, :epsilon)
 
 julia> st2 = Optimisers.setup(OptimiserChain(ClipGrad(), Adam()), m)
-(vec = Leaf(OptimiserChain(ClipGrad{Float32}(10.0), Adam{Float32}(0.001, (0.9, 0.999), 1.19209f-7)), [nothing, (Float32[0.0, 0.0], Float32[0.0, 0.0], (0.9, 0.999))]), fun = nothing)
+(vec = Leaf(OptimiserChain(ClipGrad{Float32}(10.0), Adam{Float32}(0.001, (0.9, 0.999), 1.19209f-7)), (nothing, (Float32[0.0, 0.0], Float32[0.0, 0.0], (0.9, 0.999)))), fun = ())
 
 julia> Optimisers.adjust(st2; beta = (0.777, 0.909), delta = 11.1)  # delta acts on ClipGrad
-(vec = Leaf(OptimiserChain(ClipGrad{Float32}(11.1), Adam{Float32}(0.001, (0.777, 0.909), 1.19209f-7)), [nothing, (Float32[0.0, 0.0], Float32[0.0, 0.0], (0.9, 0.999))]), fun = nothing)
+(vec = Leaf(OptimiserChain(ClipGrad{Float32}(11.1), Adam{Float32}(0.001, (0.777, 0.909), 1.19209f-7)), (nothing, (Float32[0.0, 0.0], Float32[0.0, 0.0], (0.9, 0.999)))), fun = ())
 
 julia> Optimisers.adjust(st; beta = "no such field")  # silently ignored!
-(vec = Leaf(Nesterov{Float32}(0.001, 0.9), Float32[-0.016, -0.088]), fun = nothing)
+(vec = Leaf(Nesterov{Float32}(0.001, 0.9), Float32[-0.016, -0.088]), fun = ())
 ```
 """
 adjust(tree, eta::Real) = map(st -> adjust(st, eta), tree)

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -607,7 +607,7 @@ julia> o = OptimiserChain(ClipGrad(1.0), Descent(0.1));
 julia> m = (zeros(3),);
 
 julia> s = Optimisers.setup(o, m)
-(Leaf(OptimiserChain(ClipGrad{Float64}(1.0), Descent{Float64}(0.1)), [nothing, nothing]),)
+(Leaf(OptimiserChain(ClipGrad{Float64}(1.0), Descent{Float64}(0.1)), (nothing, nothing)),)
 
 julia> Optimisers.update(s, m, ([0.3, 1, 7],))[2]  # clips before discounting
 ([-0.03, -0.1, -0.1],)


### PR DESCRIPTION
I noticed that `OptimiserChain` was not marked `@functor`; this PR marks it as such to allow one to modify the rules internal to `OptimiserChain` via `fmap`.

I also modified the optimiser chain state to be a `Tuple` instead of an `AbstractArray` for better type inference in `apply!(o::OptimiserChain, ...)`. If this is considered breaking/undesired I can remove it from the PR. Example of the improved inference:

```julia
x = zeros(Float32, 3)
dx = zero(x)
rule = AdamW()
state = Optimisers.setup(rule, x)
@code_warntype Optimisers.apply!(rule, state.state, x, dx)
```

Before:

```julia
MethodInstance for Optimisers.apply!(::OptimiserChain{Tuple{Adam{Float32}, WeightDecay{Float32}}}, ::Vector{Union{Nothing, Tuple{Vector{Float32}, Vector{Float32}, Tuple{Float32, Float32}}}}, ::Vector{Float32}, ::Vector{Float32})
  from apply!(o::OptimiserChain, states, x, dx, dxs...) in Optimisers at /home/jdoucette/.julia/dev/Optimisers/src/rules.jl:623
Arguments
  #self#::Core.Const(Optimisers.apply!)
  o::OptimiserChain{Tuple{Adam{Float32}, WeightDecay{Float32}}}
  states::Vector{Union{Nothing, Tuple{Vector{Float32}, Vector{Float32}, Tuple{Float32, Float32}}}}
  x::Vector{Float32}
  dx@_5::Vector{Float32}
  dxs::Tuple{}
Locals
  @_7::Union{Nothing, Tuple{Tuple{Int64, Tuple{Union{Adam{Float32}, WeightDecay{Float32}}, Union{Nothing, Tuple{Vector{Float32}, Vector{Float32}, Tuple{Float32, Float32}}}}}, Tuple{Int64, Tuple{Int64, Int64}}}}
  new_states::Vector{Union{Nothing, Tuple{Vector{Float32}, Vector{Float32}, Tuple{Float32, Float32}}}}
  @_9::Int64
  @_10::Int64
  @_11::Int64
  state::Union{Nothing, Tuple{Vector{Float32}, Vector{Float32}, Tuple{Float32, Float32}}}
  opt::Union{Adam{Float32}, WeightDecay{Float32}}
  i::Int64
  dx@_15::Any
Body::Tuple{Vector{Union{Nothing, Tuple{Vector{Float32}, Vector{Float32}, Tuple{Float32, Float32}}}}, Any}
1 ─       (dx@_15 = dx@_5)
│         (new_states = Optimisers.similar(states))
│   %3  = Base.getproperty(o, :opts)::Tuple{Adam{Float32}, WeightDecay{Float32}}
│   %4  = Optimisers.zip(%3, states)::Base.Iterators.Zip{Tuple{Tuple{Adam{Float32}, WeightDecay{Float32}}, Vector{Union{Nothing, Tuple{Vector{Float32}, Vector{Float32}, Tuple{Float32, Float32}}}}}}
│   %5  = Optimisers.enumerate(%4)::Base.Iterators.Enumerate{Base.Iterators.Zip{Tuple{Tuple{Adam{Float32}, WeightDecay{Float32}}, Vector{Union{Nothing, Tuple{Vector{Float32}, Vector{Float32}, Tuple{Float32, Float32}}}}}}}
│         (@_7 = Base.iterate(%5))
│   %7  = (@_7::Union{Nothing, Tuple{Tuple{Int64, Tuple{Adam{Float32}, Union{Nothing, Tuple{Vector{Float32}, Vector{Float32}, Tuple{Float32, Float32}}}}}, Tuple{Int64, Tuple{Int64, Int64}}}} === nothing)::Bool
│   %8  = Base.not_int(%7)::Bool
└──       goto #4 if not %8
2 ┄ %10 = @_7::Tuple{Tuple{Int64, Tuple{Union{Adam{Float32}, WeightDecay{Float32}}, Union{Nothing, Tuple{Vector{Float32}, Vector{Float32}, Tuple{Float32, Float32}}}}}, Tuple{Int64, Tuple{Int64, Int64}}}
│   %11 = Core.getfield(%10, 1)::Tuple{Int64, Tuple{Union{Adam{Float32}, WeightDecay{Float32}}, Union{Nothing, Tuple{Vector{Float32}, Vector{Float32}, Tuple{Float32, Float32}}}}}
│   %12 = Base.indexed_iterate(%11, 1)::Core.PartialStruct(Tuple{Int64, Int64}, Any[Int64, Core.Const(2)])
│         (i = Core.getfield(%12, 1))
│         (@_11 = Core.getfield(%12, 2))
│   %15 = Base.indexed_iterate(%11, 2, @_11::Core.Const(2))::Core.PartialStruct(Tuple{Tuple{Union{Adam{Float32}, WeightDecay{Float32}}, Union{Nothing, Tuple{Vector{Float32}, Vector{Float32}, Tuple{Float32, Float32}}}}, Int64}, Any[Tuple{Union{Adam{Float32}, WeightDecay{Float32}}, Union{Nothing, Tuple{Vector{Float32}, Vector{Float32}, Tuple{Float32, Float32}}}}, Core.Const(3)])
│   %16 = Core.getfield(%15, 1)::Tuple{Union{Adam{Float32}, WeightDecay{Float32}}, Union{Nothing, Tuple{Vector{Float32}, Vector{Float32}, Tuple{Float32, Float32}}}}
│   %17 = Base.indexed_iterate(%16, 1)::Core.PartialStruct(Tuple{Union{Adam{Float32}, WeightDecay{Float32}}, Int64}, Any[Union{Adam{Float32}, WeightDecay{Float32}}, Core.Const(2)])
│         (opt = Core.getfield(%17, 1))
│         (@_10 = Core.getfield(%17, 2))
│   %20 = Base.indexed_iterate(%16, 2, @_10::Core.Const(2))::Core.PartialStruct(Tuple{Union{Nothing, Tuple{Vector{Float32}, Vector{Float32}, Tuple{Float32, Float32}}}, Int64}, Any[Union{Nothing, Tuple{Vector{Float32}, Vector{Float32}, Tuple{Float32, Float32}}}, Core.Const(3)])
│         (state = Core.getfield(%20, 1))
│   %22 = Core.getfield(%10, 2)::Tuple{Int64, Tuple{Int64, Int64}}
│   %23 = Core.tuple(opt, state, x, dx@_15)::Tuple{Union{Adam{Float32}, WeightDecay{Float32}}, Union{Nothing, Tuple{Vector{Float32}, Vector{Float32}, Tuple{Float32, Float32}}}, Vector{Float32}, Any}
│   %24 = Core._apply_iterate(Base.iterate, Optimisers.apply!, %23, dxs)::Tuple{Union{Nothing, Tuple{Any, Any, Tuple{Float32, Float32}}}, Any}
│   %25 = Base.indexed_iterate(%24, 1)::Core.PartialStruct(Tuple{Union{Nothing, Tuple{Any, Any, Tuple{Float32, Float32}}}, Int64}, Any[Union{Nothing, Tuple{Any, Any, Tuple{Float32, Float32}}}, Core.Const(2)])
│   %26 = Core.getfield(%25, 1)::Union{Nothing, Tuple{Any, Any, Tuple{Float32, Float32}}}
│         (@_9 = Core.getfield(%25, 2))
│   %28 = Base.indexed_iterate(%24, 2, @_9::Core.Const(2))::Tuple{Any, Int64}
│         (dx@_15 = Core.getfield(%28, 1))
│         Base.setindex!(new_states, %26, i)
│         (@_7 = Base.iterate(%5, %22))
│   %32 = (@_7 === nothing)::Bool
│   %33 = Base.not_int(%32)::Bool
└──       goto #4 if not %33
3 ─       goto #2
4 ┄ %36 = Core.tuple(new_states, dx@_15)::Tuple{Vector{Union{Nothing, Tuple{Vector{Float32}, Vector{Float32}, Tuple{Float32, Float32}}}}, Any}
└──       return %36
```

After:

```julia
MethodInstance for Optimisers.apply!(::OptimiserChain{Tuple{Adam{Float32}, WeightDecay{Float32}}}, ::Tuple{Tuple{Vector{Float32}, Vector{Float32}, Tuple{Float32, Float32}}, Nothing}, ::Vector{Float32}, ::Vector{Float32})
  from apply!(o::OptimiserChain, states, x, dx, dxs...) in Optimisers at /home/jdoucette/.julia/dev/Optimisers/src/rules.jl:625
Arguments
  #self#::Core.Const(Optimisers.apply!)
  o::OptimiserChain{Tuple{Adam{Float32}, WeightDecay{Float32}}}
  states::Tuple{Tuple{Vector{Float32}, Vector{Float32}, Tuple{Float32, Float32}}, Nothing}
  x::Vector{Float32}
  dx::Vector{Float32}
  dxs::Tuple{}
Locals
  #81::Optimisers.var"#81#82"{Vector{Float32}, Tuple{}}
Body::Tuple{Tuple{Tuple{Vector{Float32}, Vector{Float32}, Tuple{Float32, Float32}}, Nothing}, Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Tuple{Base.OneTo{Int64}}, typeof(+), Tuple{Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Tuple{Base.OneTo{Int64}}, typeof(*), Tuple{Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Nothing, typeof(/), Tuple{Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Nothing, typeof(/), Tuple{Vector{Float32}, Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{0}, Nothing, typeof(-), Tuple{Int64, Float32}}}}, Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Nothing, typeof(+), Tuple{Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Nothing, typeof(sqrt), Tuple{Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Nothing, typeof(/), Tuple{Vector{Float32}, Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{0}, Nothing, typeof(-), Tuple{Int64, Float32}}}}}}, Float32}}}}, Float32}}, Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Nothing, typeof(*), Tuple{Float32, Vector{Float32}}}}}}
1 ─ %1  = Optimisers.:(var"#81#82")::Core.Const(Optimisers.var"#81#82")
│   %2  = Core.typeof(x)::Core.Const(Vector{Float32})
│   %3  = Core.typeof(dxs)::Core.Const(Tuple{})
│   %4  = Core.apply_type(%1, %2, %3)::Core.Const(Optimisers.var"#81#82"{Vector{Float32}, Tuple{}})
│         (#81 = %new(%4, x, dxs))
│   %6  = #81::Optimisers.var"#81#82"{Vector{Float32}, Tuple{}}
│   %7  = (:init,)::Core.Const((:init,))
│   %8  = Core.apply_type(Core.NamedTuple, %7)::Core.Const(NamedTuple{(:init,)})
│   %9  = ()::Core.Const(())
│   %10 = Core.tuple(%9, dx)::Tuple{Tuple{}, Vector{Float32}}
│   %11 = Core.tuple(%10)::Tuple{Tuple{Tuple{}, Vector{Float32}}}
│   %12 = (%8)(%11)::NamedTuple{(:init,), Tuple{Tuple{Tuple{}, Vector{Float32}}}}
│   %13 = Core.kwfunc(Optimisers.foldl)::Core.Const(Base.var"#foldl##kw"())
│   %14 = Base.getproperty(o, :opts)::Tuple{Adam{Float32}, WeightDecay{Float32}}
│   %15 = Base.broadcasted(Optimisers.tuple, %14, states)::Base.Broadcast.Broadcasted{Base.Broadcast.Style{Tuple}, Nothing, typeof(tuple), Tuple{Tuple{Adam{Float32}, WeightDecay{Float32}}, Tuple{Tuple{Vector{Float32}, Vector{Float32}, Tuple{Float32, Float32}}, Nothing}}}
│   %16 = Base.materialize(%15)::Tuple{Tuple{Adam{Float32}, Tuple{Vector{Float32}, Vector{Float32}, Tuple{Float32, Float32}}}, Tuple{WeightDecay{Float32}, Nothing}}
│   %17 = (%13)(%12, Optimisers.foldl, %6, %16)::Core.PartialStruct(Tuple{Tuple{Tuple{Vector{Float32}, Vector{Float32}, Tuple{Float32, Float32}}, Nothing}, Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Tuple{Base.OneTo{Int64}}, typeof(+), Tuple{Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Tuple{Base.OneTo{Int64}}, typeof(*), Tuple{Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Nothing, typeof(/), Tuple{Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Nothing, typeof(/), Tuple{Vector{Float32}, Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{0}, Nothing, typeof(-), Tuple{Int64, Float32}}}}, Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Nothing, typeof(+), Tuple{Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Nothing, typeof(sqrt), Tuple{Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Nothing, typeof(/), Tuple{Vector{Float32}, Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{0}, Nothing, typeof(-), Tuple{Int64, Float32}}}}}}, Float32}}}}, Float32}}, Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Nothing, typeof(*), Tuple{Float32, Vector{Float32}}}}}}, Any[Tuple{Tuple{Vector{Float32}, Vector{Float32}, Tuple{Float32, Float32}}, Nothing}, Core.PartialStruct(Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Tuple{Base.OneTo{Int64}}, typeof(+), Tuple{Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Tuple{Base.OneTo{Int64}}, typeof(*), Tuple{Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Nothing, typeof(/), Tuple{Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Nothing, typeof(/), Tuple{Vector{Float32}, Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{0}, Nothing, typeof(-), Tuple{Int64, Float32}}}}, Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Nothing, typeof(+), Tuple{Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Nothing, typeof(sqrt), Tuple{Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Nothing, typeof(/), Tuple{Vector{Float32}, Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{0}, Nothing, typeof(-), Tuple{Int64, Float32}}}}}}, Float32}}}}, Float32}}, Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Nothing, typeof(*), Tuple{Float32, Vector{Float32}}}}}, Any[Core.Const(+), Core.PartialStruct(Tuple{Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Tuple{Base.OneTo{Int64}}, typeof(*), Tuple{Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Nothing, typeof(/), Tuple{Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Nothing, typeof(/), Tuple{Vector{Float32}, Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{0}, Nothing, typeof(-), Tuple{Int64, Float32}}}}, Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Nothing, typeof(+), Tuple{Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Nothing, typeof(sqrt), Tuple{Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Nothing, typeof(/), Tuple{Vector{Float32}, Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{0}, Nothing, typeof(-), Tuple{Int64, Float32}}}}}}, Float32}}}}, Float32}}, Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Nothing, typeof(*), Tuple{Float32, Vector{Float32}}}}, Any[Core.PartialStruct(Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Tuple{Base.OneTo{Int64}}, typeof(*), Tuple{Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Nothing, typeof(/), Tuple{Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Nothing, typeof(/), Tuple{Vector{Float32}, Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{0}, Nothing, typeof(-), Tuple{Int64, Float32}}}}, Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Nothing, typeof(+), Tuple{Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Nothing, typeof(sqrt), Tuple{Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Nothing, typeof(/), Tuple{Vector{Float32}, Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{0}, Nothing, typeof(-), Tuple{Int64, Float32}}}}}}, Float32}}}}, Float32}}, Any[Core.Const(*), Core.PartialStruct(Tuple{Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Nothing, typeof(/), Tuple{Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Nothing, typeof(/), Tuple{Vector{Float32}, Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{0}, Nothing, typeof(-), Tuple{Int64, Float32}}}}, Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Nothing, typeof(+), Tuple{Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Nothing, typeof(sqrt), Tuple{Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Nothing, typeof(/), Tuple{Vector{Float32}, Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{0}, Nothing, typeof(-), Tuple{Int64, Float32}}}}}}, Float32}}}}, Float32}, Any[Core.PartialStruct(Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Nothing, typeof(/), Tuple{Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Nothing, typeof(/), Tuple{Vector{Float32}, Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{0}, Nothing, typeof(-), Tuple{Int64, Float32}}}}, Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Nothing, typeof(+), Tuple{Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Nothing, typeof(sqrt), Tuple{Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Nothing, typeof(/), Tuple{Vector{Float32}, Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{0}, Nothing, typeof(-), Tuple{Int64, Float32}}}}}}, Float32}}}}, Any[Core.Const(/), Core.PartialStruct(Tuple{Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Nothing, typeof(/), Tuple{Vector{Float32}, Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{0}, Nothing, typeof(-), Tuple{Int64, Float32}}}}, Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Nothing, typeof(+), Tuple{Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Nothing, typeof(sqrt), Tuple{Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Nothing, typeof(/), Tuple{Vector{Float32}, Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{0}, Nothing, typeof(-), Tuple{Int64, Float32}}}}}}, Float32}}}, Any[Core.PartialStruct(Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Nothing, typeof(/), Tuple{Vector{Float32}, Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{0}, Nothing, typeof(-), Tuple{Int64, Float32}}}}, Any[Core.Const(/), Core.PartialStruct(Tuple{Vector{Float32}, Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{0}, Nothing, typeof(-), Tuple{Int64, Float32}}}, Any[Vector{Float32}, Core.PartialStruct(Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{0}, Nothing, typeof(-), Tuple{Int64, Float32}}, Any[Core.Const(-), Core.PartialStruct(Tuple{Int64, Float32}, Any[Core.Const(1), Float32]), Core.Const(nothing)])]), Core.Const(nothing)]), Core.PartialStruct(Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Nothing, typeof(+), Tuple{Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Nothing, typeof(sqrt), Tuple{Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Nothing, typeof(/), Tuple{Vector{Float32}, Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{0}, Nothing, typeof(-), Tuple{Int64, Float32}}}}}}, Float32}}, Any[Core.Const(+), Core.PartialStruct(Tuple{Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Nothing, typeof(sqrt), Tuple{Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Nothing, typeof(/), Tuple{Vector{Float32}, Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{0}, Nothing, typeof(-), Tuple{Int64, Float32}}}}}}, Float32}, Any[Core.PartialStruct(Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Nothing, typeof(sqrt), Tuple{Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Nothing, typeof(/), Tuple{Vector{Float32}, Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{0}, Nothing, typeof(-), Tuple{Int64, Float32}}}}}}, Any[Core.Const(sqrt), Core.PartialStruct(Tuple{Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Nothing, typeof(/), Tuple{Vector{Float32}, Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{0}, Nothing, typeof(-), Tuple{Int64, Float32}}}}}, Any[Core.PartialStruct(Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Nothing, typeof(/), Tuple{Vector{Float32}, Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{0}, Nothing, typeof(-), Tuple{Int64, Float32}}}}, Any[Core.Const(/), Core.PartialStruct(Tuple{Vector{Float32}, Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{0}, Nothing, typeof(-), Tuple{Int64, Float32}}}, Any[Vector{Float32}, Core.PartialStruct(Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{0}, Nothing, typeof(-), Tuple{Int64, Float32}}, Any[Core.Const(-), Core.PartialStruct(Tuple{Int64, Float32}, Any[Core.Const(1), Float32]), Core.Const(nothing)])]), Core.Const(nothing)])]), Core.Const(nothing)]), Float32]), Core.Const(nothing)])]), Core.Const(nothing)]), Float32]), Tuple{Base.OneTo{Int64}}]), Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Nothing, typeof(*), Tuple{Float32, Vector{Float32}}}]), Tuple{Base.OneTo{Int64}}])])
└──       return %17
```
