### PR TITLE
Simple docs change

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -43,8 +43,8 @@ all `isnumeric` leaf nodes.
 To further restrict this by ignoring some fields of a layer type, define `trainable`:
 
 ```@docs
-Optimisers.isnumeric
 Optimisers.trainable
+Optimisers.isnumeric
 ```
 
 Such restrictions are also obeyed by this function for flattening a model:


### PR DESCRIPTION
Seems this paragraph wants to have docs for `trainable` just below it.