### PR TITLE
fix: rm Functors@0.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Optimisers"
 uuid = "3bd65402-5787-11e9-1adc-39752487f4e2"
 authors = ["Mike J Innes <mike.j.innes@gmail.com>"]
-version = "0.2.16"
+version = "0.2.17"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
@@ -12,7 +12,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 ChainRulesCore = "1"
-Functors = "0.3, 0.4"
+Functors = "0.4"
 Yota = "0.8.2"
 Zygote = "0.6.40"
 julia = "1.6"


### PR DESCRIPTION
`AbstractWalk` was introduced in Functors@0.4.0 (https://github.com/FluxML/Functors.jl/blob/v0.4.0/src/walks.jl)

