### PR TITLE
Rule for mixed precision training

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -29,9 +29,10 @@ In addition to the main course, you may wish to order some of these condiments:
 Optimisers.AccumGrad
 Optimisers.ClipGrad
 Optimisers.ClipNorm
+Optimisers.MixedPrecision
+Optimisers.OptimiserChain
 Optimisers.SignDecay
 Optimisers.WeightDecay
-Optimisers.OptimiserChain
 ```
 
 ## Model Interface

--- a/src/Optimisers.jl
+++ b/src/Optimisers.jl
@@ -24,7 +24,7 @@ include("rules.jl")
 export Descent, Adam, Momentum, Nesterov, Rprop, RMSProp,
        AdaGrad, AdaMax, AdaDelta, AMSGrad, NAdam, AdamW, RAdam, OAdam, AdaBelief,
        WeightDecay, SignDecay, ClipGrad, ClipNorm, OptimiserChain, Lion,
-       AccumGrad
+       AccumGrad, MixedPrecision
 
 VERSION >= v"1.11.0-DEV.469" && eval(Meta.parse("public apply!, init, setup, update, update!"))
 

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -858,8 +858,7 @@ function apply!(o::AccumGrad, state, x, dx)
 end
 
 """
-    MixedPrecision(opt)
-    MixedPrecision{T}(opt)
+    MixedPrecision([T = Float32,] opt)
 
 An optimiser that wraps another optimiser `opt` in order to perform mixed precision
 training [1]. 
@@ -879,14 +878,14 @@ then `x` is updated with the value of `xT`.
 # Examples
 
 ```julia
-x = rand(Float16, 2) # a trainable parameter in low precision
+x = rand(Float16, 2) # A trainable parameter in low precision
 
-opt = MixedPrecision(Adam(1e-3)) 
-opt_state = Optimisers.setup(opt, x) # the state contains a copy of x in Float32 precision
+opt = MixedPrecision(Adam(1e-3)) # Equivalent to MixedPrecision(Float32, Adam(1e-3))
+opt_state = Optimisers.setup(opt, x) # The state contains a copy of x in Float32 precision
 
-g = rand(Float16, 2) # a gradient in low precision
+g = rand(Float16, 2) # A gradient in low precision
 
-# accumulation is performed in high precision,
+# Accumulation is performed in high precision,
 # then also the low precision x is synced
 Optimisers.update!(opt_state, x, g)  
 ```
@@ -898,7 +897,7 @@ end
 @functor MixedPrecision
 
 MixedPrecision(opt::AbstractRule) = MixedPrecision{Float32, typeof(opt)}(opt)
-MixedPrecision{T}(opt::AbstractRule) where T = MixedPrecision{T, typeof(opt)}(opt)
+MixedPrecision(T::Type, opt::AbstractRule) = MixedPrecision{T, typeof(opt)}(opt)
 
 function init(o::MixedPrecision{T}, x::AbstractArray) where T
   xT = T.(x)

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -899,17 +899,20 @@ end
 MixedPrecision(opt::AbstractRule) = MixedPrecision{Float32, typeof(opt)}(opt)
 MixedPrecision{T}(opt::AbstractRule) where T = MixedPrecision{T, typeof(opt)}(opt)
 
-to_precision(::Type{T}, x::AbstractArray) where T = convert(AbstractArray{T}, x)
-
-function init(o::MixedPrecision{T}, x) where T
-  xT = to_precision(T, x)
+function init(o::MixedPrecision{T}, x::AbstractArray) where T
+  xT = T.(x)
   return (xT, init(o.opt, xT))
 end
 
 function apply!(o::MixedPrecision{T}, state, x, dx) where T
   xT, st = state
   st′, dx′ = apply!(o.opt, st, xT, dx)
-  subtract!(xT, dx′)
-  @. x = xT
-  return (xT, st′), nothing
+  xT = subtract!(xT, dx′)
+  if maywrite(x)
+    x .= xT
+    dx′ = nothing
+  else
+    dx′ = x .- eltype(x).(xT)
+  end
+  return (xT, st′), dx′
 end

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -896,6 +896,8 @@ struct MixedPrecision{T<:Number, O<:AbstractRule} <: AbstractRule
   opt::O
 end
 
+@functor MixedPrecision
+
 MixedPrecision(opt::AbstractRule) = MixedPrecision{Float32, typeof(opt)}(opt)
 MixedPrecision{T}(opt::AbstractRule) where T = MixedPrecision{T, typeof(opt)}(opt)
 
@@ -916,3 +918,6 @@ function apply!(o::MixedPrecision{T}, state, x, dx) where T
   end
   return (xT, st′), dx′
 end
+
+adjust(o::MixedPrecision, eta::Real) = MixedPrecision(adjust(o.opt, eta))
+adjust(o::MixedPrecision; kw...) = MixedPrecision(adjust(o.opt; kw...))

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -856,3 +856,25 @@ function apply!(o::AccumGrad, state, x, dx)
     return (accum_dx, counter + 1), nothing
   end
 end
+
+struct MixedPrecision{T<:Number, O<:AbstractRule} <: AbstractRule
+  opt::O
+end
+
+MixedPrecision(opt::AbstractRule) = MixedPrecision{Float32, typeof(opt)}(opt)
+MixedPrecision{T}(opt::AbstractRule) where T = MixedPrecision{T, typeof(opt)}(opt)
+
+to_precision(::Type{T}, x::AbstractArray) where T = convert(AbstractArray{T}, x)
+
+function init(o::MixedPrecision{T}, x) where T
+  xT = to_precision(T, x)
+  return (xT, init(o.opt, xT))
+end
+
+function apply!(o::MixedPrecision{T}, state, x, dx) where T
+  xT, st = state
+  st′, dx′ = apply!(o.opt, st, xT, dx)
+  subtract!(xT, dx′)
+  @. x = xT
+  return (xT, st′), nothing
+end

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -910,7 +910,7 @@ function apply!(o::MixedPrecision{T}, state, x, dx) where T
   xT = subtract!(xT, dx′)
   if maywrite(x)
     x .= xT
-    dx′ = Zero()
+    dx′ = nothing
   else
     dx′ = x .- eltype(x).(xT)
   end

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -912,7 +912,7 @@ function apply!(o::MixedPrecision{T}, state, x, dx) where T
   xT = subtract!(xT, dx′)
   if maywrite(x)
     x .= xT
-    dx′ = nothing
+    dx′ = Zero()
   else
     dx′ = x .- eltype(x).(xT)
   end

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -776,7 +776,11 @@ julia> Optimisers.update(s, m, ([0.3, 1, 7],))[2]  # clips before discounting
 struct OptimiserChain{O<:Tuple} <: AbstractRule
   opts::O
 end
-OptimiserChain(opts...) = OptimiserChain(opts)
+
+function OptimiserChain(opts...)
+  any(opt -> opt isa MixedPrecision, opts) && throw(ArgumentError("MixedPrecision optimisers should wrap the entire OptimiserChain, not be inside it."))
+  return OptimiserChain(opts)
+end
 
 @functor OptimiserChain
 
@@ -872,6 +876,8 @@ Call `g` the gradient of `x`. Both `g` and `x` are typically in a precision lowe
 
 In the `update!(opt_state, x, g)` call, `opt` is used to update `xT` instead of `x`, 
 then `x` is updated with the value of `xT`. 
+
+# Reference
 
 [1] Micikevicius et al. '17, "Mixed Precision Training", https://arxiv.org/abs/1710.03740 .
 

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -918,7 +918,7 @@ function apply!(o::MixedPrecision{T}, state, x, dx) where T
     x .= xT
     dx′ = nothing
   else
-    dx′ = x .- eltype(x).(xT)
+    dx′ = eltype(x).(x .- xT)
   end
   return (xT, st′), dx′
 end

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -864,9 +864,8 @@ end
 An optimiser that wraps another optimiser `opt` in order to perform mixed precision
 training [1]. 
 
-The state of `MixedPrecision` will contain a copy in precision `T` of the trainable parameter `x`, 
-call it `xT`. 
-The internal state of `opt` also operates at precision `T`.
+The state of `MixedPrecision{T}` will contain a copy in precision `T` of any trainable parameter `x`, 
+call it `xT`, as well as the internal state of `opt` also at precision `T`.
 If `T` is not specified, it defaults to `Float32`.
 
 Call `g` the gradient of `x`. Both `g` and `x` are typically in a precision lower than `T`

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -891,22 +891,22 @@ Optimisers.update!(opt_state, x, g)
 ```
 """
 struct MixedPrecision{T<:Number, O<:AbstractRule} <: AbstractRule
-  opt::O
+  rule::O
 end
 
 @functor MixedPrecision
 
-MixedPrecision(opt::AbstractRule) = MixedPrecision{Float32, typeof(opt)}(opt)
-MixedPrecision(T::Type, opt::AbstractRule) = MixedPrecision{T, typeof(opt)}(opt)
+MixedPrecision(rule::AbstractRule) = MixedPrecision{Float32, typeof(rule)}(rule)
+MixedPrecision(T::Type, rule::AbstractRule) = MixedPrecision{T, typeof(rule)}(rule)
 
 function init(o::MixedPrecision{T}, x::AbstractArray) where T
   xT = T.(x)
-  return (xT, init(o.opt, xT))
+  return (xT, init(o.rule, xT))
 end
 
 function apply!(o::MixedPrecision{T}, state, x, dx) where T
   xT, st = state
-  st′, dx′ = apply!(o.opt, st, xT, dx)
+  st′, dx′ = apply!(o.rule, st, xT, dx)
   xT = subtract!(xT, dx′)
   if maywrite(x)
     x .= xT
@@ -917,5 +917,5 @@ function apply!(o::MixedPrecision{T}, state, x, dx) where T
   return (xT, st′), dx′
 end
 
-adjust(o::MixedPrecision, eta::Real) = MixedPrecision(adjust(o.opt, eta))
-adjust(o::MixedPrecision; kw...) = MixedPrecision(adjust(o.opt; kw...))
+adjust(o::MixedPrecision{T}, eta::Real) where T = MixedPrecision(T, adjust(o.rule, eta))
+adjust(o::MixedPrecision{T}; kw...) where T = MixedPrecision(T, adjust(o.rule; kw...))

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -857,6 +857,41 @@ function apply!(o::AccumGrad, state, x, dx)
   end
 end
 
+"""
+    MixedPrecision(opt)
+    MixedPrecision{T}(opt)
+
+An optimiser that wraps another optimiser `opt` in order to perform mixed precision
+training [1]. 
+
+The state of `MixedPrecision` will contain a copy in precision `T` of the trainable parameter `x`, 
+call it `xT`. 
+The internal state of `opt` also operates at precision `T`.
+If `T` is not specified, it defaults to `Float32`.
+
+Call `g` the gradient of `x`. Both `g` and `x` are typically in a precision lower than `T`
+(e.g. `Float16`).
+
+In the `update!(opt_state, x, g)` call, `opt` is used to update `xT` instead of `x`, 
+then `x` is updated with the value of `xT`. 
+
+[1] Micikevicius et al. '17, "Mixed Precision Training", https://arxiv.org/abs/1710.03740 .
+
+# Examples
+
+```julia
+x = rand(Float16, 2) # a trainable parameter in low precision
+
+opt = MixedPrecision(Adam(1e-3)) 
+opt_state = Optimisers.setup(opt, x) # the state contains a copy of x in Float32 precision
+
+g = rand(Float16, 2) # a gradient in low precision
+
+# accumulation is performed in high precision,
+# then also the low precision x is synced
+Optimisers.update!(opt_state, x, g)  
+```
+"""
 struct MixedPrecision{T<:Number, O<:AbstractRule} <: AbstractRule
   opt::O
 end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -10,3 +10,6 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
+
+[sources]
+Optimisers = { path = ".." }

--- a/test/rules.jl
+++ b/test/rules.jl
@@ -9,7 +9,7 @@ RULES = [
   Descent(), Adam(), Momentum(), Nesterov(), Rprop(), RMSProp(),
   AdaGrad(), AdaMax(), AdaDelta(), AMSGrad(), NAdam(),
   AdamW(), RAdam(), OAdam(), AdaBelief(), Lion(),
-  MixedPrecision{Float64}(Adam()),
+  MixedPrecision(Float64, Adam()),
   # A few chained combinations:
   OptimiserChain(SignDecay(0.001), Adam(0.001)),
   OptimiserChain(ClipNorm(), Adam(0.001)),
@@ -275,7 +275,7 @@ end
   @test new_x ≈ x .- 1e-3 .* g
 
   x = rand(Float16, 2)
-  opt_state = Optimisers.setup(MixedPrecision{Float64}(Adam(1e-3)), x)
+  opt_state = Optimisers.setup(MixedPrecision(Float64, Adam(1e-3)), x)
   @test opt_state.state[1] isa Vector{Float64}
   @test opt_state.state[2][1] isa Vector{Float64}  
 end

--- a/test/rules.jl
+++ b/test/rules.jl
@@ -277,5 +277,11 @@ end
   x = rand(Float16, 2)
   opt_state = Optimisers.setup(MixedPrecision(Float64, Adam(1e-3)), x)
   @test opt_state.state[1] isa Vector{Float64}
-  @test opt_state.state[2][1] isa Vector{Float64}  
+  @test opt_state.state[2][1] isa Vector{Float64}
+
+  # test adjust
+  opt = MixedPrecision(Float64, Adam(1e-3))
+  opt2 = Optimisers.adjust(opt, 2e-3)
+  @test opt2.rule.eta == 2e-3
+  @test opt2 isa MixedPrecision{Float64, <:Adam}
 end

--- a/test/rules.jl
+++ b/test/rules.jl
@@ -9,6 +9,7 @@ RULES = [
   Descent(), Adam(), Momentum(), Nesterov(), Rprop(), RMSProp(),
   AdaGrad(), AdaMax(), AdaDelta(), AMSGrad(), NAdam(),
   AdamW(), RAdam(), OAdam(), AdaBelief(), Lion(),
+  MixedPrecision{Float64}(Adam()),
   # A few chained combinations:
   OptimiserChain(SignDecay(0.001), Adam(0.001)),
   OptimiserChain(ClipNorm(), Adam(0.001)),
@@ -261,4 +262,20 @@ end
   os = Optimisers.setup(Adam(1e-4), x);
   os, x = Optimisers.update(os, x, δx)
   @test x ≈ Float16[1.835, -0.886, 0.5493] rtol=1e-3
+end
+
+@testset "MixedPrecision" begin
+  x = rand(Float16, 2)
+  opt_state = Optimisers.setup(MixedPrecision(Adam(1e-3)), x)
+  @test opt_state.state[1] isa Vector{Float32}
+  @test opt_state.state[2][1] isa Vector{Float32}
+  g = rand(Float16, 2)
+  new_state, new_x = Optimisers.update(opt_state, x, rand(Float16, 2))
+  @test new_x == Float16.(new_state.state[1])
+  @test new_x ≈ x .- 1e-3 .* g
+
+  x = rand(Float16, 2)
+  opt_state = Optimisers.setup(MixedPrecision{Float64}(Adam(1e-3)), x)
+  @test opt_state.state[1] isa Vector{Float64}
+  @test opt_state.state[2][1] isa Vector{Float64}  
 end

--- a/test/rules.jl
+++ b/test/rules.jl
@@ -279,9 +279,10 @@ end
   @test opt_state.state[1] isa Vector{Float64}
   @test opt_state.state[2][1] isa Vector{Float64}
 
-  # test adjust
   opt = MixedPrecision(Float64, Adam(1e-3))
   opt2 = Optimisers.adjust(opt, 2e-3)
   @test opt2.rule.eta == 2e-3
   @test opt2 isa MixedPrecision{Float64, <:Adam}
+
+  @test_throws ArgumentError OptimiserChain(MixedPrecision(Adam()))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -260,17 +260,17 @@ end
 
       # MixedPrecision
       mp = Optimisers.setup(MixedPrecision(Momentum(0.1, 0.9)), m)
-      mp1, mp2 = Optimisers.update(mp, m, (α = nothing, γ = [1,10,100],))
-      @test mp1.γ.rule.opt.eta == 0.1
+      mp1, _ = Optimisers.update(mp, m, (α = nothing, γ = [1,10,100],))
+      @test mp1.γ.rule.rule.eta == 0.1
       @test mp1.γ.state[2] ≈ [0.1, 1, 10]
 
       mp2 = Optimisers.adjust(mp1, 0.2)
-      @test mp2.γ.rule.opt.eta == 0.2
-      @test mp2.γ.rule.opt.rho == 0.9
+      @test mp2.γ.rule.rule.eta == 0.2
+      @test mp2.γ.rule.rule.rho == 0.9
 
       mp3 = Optimisers.adjust(mp1; eta=0.3, rho=0.7)
-      @test mp3.γ.rule.opt.eta == 0.3
-      @test mp3.γ.rule.opt.rho == 0.7
+      @test mp3.γ.rule.rule.eta == 0.3
+      @test mp3.γ.rule.rule.rho == 0.7
     end
 
     @testset "adjusting parameters, in-place" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -301,6 +301,20 @@ end
       @test sc1.γ.rule.opts[1].delta ≈ 2.5
       @test sc1.γ.rule.opts[2].eta ≈ 0.2 # unchanged
       @test sc1.γ.state[2][1] ≈ [0.1, 0.2, 0.2]
+
+      # MixedPrecision
+      mp = Optimisers.setup(MixedPrecision(Momentum(0.1, 0.9)), m)
+      mp1, mp2 = Optimisers.update(mp, m, (α = nothing, γ = [1,10,100],))
+      @test mp1.γ.rule.opt.eta == 0.1
+      @test mp1.γ.state[2] ≈ [0.1, 1, 10]
+
+      Optimisers.adjust!(mp1, 0.2)
+      @test mp1.γ.rule.opt.eta == 0.2
+      @test mp1.γ.rule.opt.rho == 0.9
+
+      Optimisers.adjust!(mp1; eta=0.3, rho=0.7)
+      @test mp1.γ.rule.opt.eta == 0.3
+      @test mp1.γ.rule.opt.rho == 0.7
     end
 
     @testset "freeze/thaw" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -257,6 +257,20 @@ end
       @test sc2.γ.rule.opts[1].delta == 2.5
       @test sc2.γ.rule.opts[2].eta == 0.001 # unchanged
       @test sc2.γ.state[2][1] ≈ [0.1, 0.2, 0.2]
+
+      # MixedPrecision
+      mp = Optimisers.setup(MixedPrecision(Momentum(0.1, 0.9)), m)
+      mp1, mp2 = Optimisers.update(mp, m, (α = nothing, γ = [1,10,100],))
+      @test mp1.γ.rule.opt.eta == 0.1
+      @test mp1.γ.state[2] ≈ [0.1, 1, 10]
+
+      mp2 = Optimisers.adjust(mp1, 0.2)
+      @test mp2.γ.rule.opt.eta == 0.2
+      @test mp2.γ.rule.opt.rho == 0.9
+
+      mp3 = Optimisers.adjust(mp1; eta=0.3, rho=0.7)
+      @test mp3.γ.rule.opt.eta == 0.3
+      @test mp3.γ.rule.opt.rho == 0.7
     end
 
     @testset "adjusting parameters, in-place" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -318,17 +318,17 @@ end
 
       # MixedPrecision
       mp = Optimisers.setup(MixedPrecision(Momentum(0.1, 0.9)), m)
-      mp1, mp2 = Optimisers.update(mp, m, (α = nothing, γ = [1,10,100],))
-      @test mp1.γ.rule.opt.eta == 0.1
+      mp1, _ = Optimisers.update(mp, m, (α = nothing, γ = [1,10,100],))
+      @test mp1.γ.rule.rule.eta == 0.1
       @test mp1.γ.state[2] ≈ [0.1, 1, 10]
 
       Optimisers.adjust!(mp1, 0.2)
-      @test mp1.γ.rule.opt.eta == 0.2
-      @test mp1.γ.rule.opt.rho == 0.9
+      @test mp1.γ.rule.rule.eta == 0.2
+      @test mp1.γ.rule.rule.rho == 0.9
 
       Optimisers.adjust!(mp1; eta=0.3, rho=0.7)
-      @test mp1.γ.rule.opt.eta == 0.3
-      @test mp1.γ.rule.opt.rho == 0.7
+      @test mp1.γ.rule.rule.eta == 0.3
+      @test mp1.γ.rule.rule.rho == 0.7
     end
 
     @testset "freeze/thaw" begin


### PR DESCRIPTION
Implements a fundamental strategy for training big models. 
In this implementation, the high precision weights are part of the optimiser's state. 

The optimiser introduced here should be coupled to a loss scaling strategy (not in this PR, and probably not ever in this repo) to obtain robust mixed precision training.

### PR Checklist

- [x] Tests are added
- [x] Documentation, if applicable
