### PR TITLE
WeightDecay for L1 norm

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Optimisers"
 uuid = "3bd65402-5787-11e9-1adc-39752487f4e2"
 authors = ["Mike J Innes <mike.j.innes@gmail.com>"]
-version = "0.3.1"
+version = "0.3.2"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/Optimisers.jl
+++ b/src/Optimisers.jl
@@ -14,7 +14,7 @@ export destructure
 include("rules.jl")
 export Descent, Adam, Momentum, Nesterov, Rprop, RMSProp,
        AdaGrad, AdaMax, AdaDelta, AMSGrad, NAdam, AdamW, RAdam, OAdam, AdaBelief,
-       WeightDecay, ClipGrad, ClipNorm, OptimiserChain, Lion,
+       WeightDecay, SignDecay, ClipGrad, ClipNorm, OptimiserChain, Lion,
        AccumGrad
 
 ###

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -538,26 +538,32 @@ function apply!(o::AdaBelief, state, x::AbstractArray{T}, dx) where T
 end
 
 """
-    WeightDecay(γ = 5e-4)
+    WeightDecay(γ = 5e-4, ζ = 0)
 
-Decay weights by ``γ``, that is, add `γ .* x` to the gradient `x̄` which will be
-subtracted from `x`.
+Decay weights by ``γ = 0.0005``, that is, add `γ .* x` to the gradient `x̄`
+which will be subtracted from parameters `x`.
+
+The second argument adds `ζ .* sign.(x)` to the gradient, at the same time.
+This is not traditional weight decay, but similarly discourages large weights.
 
 Typically composed  with other optimisers as the first transformation in an [`OptimiserChain`](@ref).
-This is equivalent to adding ``L_2`` regularization with coefficient ``γ`` to the loss.
+This is equivalent to adding ``L_2`` regularization with coefficient ``γ`` to the loss,
+and ``L_1`` regularization with coefficient ``ζ``.
 
 # Parameters
 - Weight decay (`γ`): Decay applied to weights during optimisation.
+- Sign decay (`ζ`): umm
 """
 @def struct WeightDecay <: AbstractRule
   gamma = 5e-4
+  zeta = 0.0
 end
 
 init(o::WeightDecay, x::AbstractArray) = nothing
 
 function apply!(o::WeightDecay, state, x::AbstractArray{T}, dx) where T
-  γ = T(o.gamma)
-  dx′ = @lazy dx + γ * x
+  γ, ζ = T(o.gamma), T(o.zeta)
+  dx′ = @lazy dx + γ * x + ζ * sign(x)
 
   return state, dx′
 end

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -550,10 +550,11 @@ as the first transformation in an [`OptimiserChain`](@ref):
   function ``ℓ`` (for every parameter array `x`).
 
 * At `α == 1`, adds `λ .* sign.(x)` to the gradient. This implements ``L_1``
-  regularisation, equivalent to adding `ζ * sum(abs, x)` to the loss.
+  regularisation, equivalent to adding `λ * sum(abs, x)` (which is `λ * norm(x, 1)`)
+  to the loss.
 
-In general, it adds `@. λ * (1-α) x + λ * α sign(x)`, thus implementing
-a mixture of the two effects (equivalent to adding two terms to the loss).
+In general, it adds `@. λ * (1-α) * x + λ * α * sign(x)` to the gradient, thus implementing
+a mixture of the two effects, equivalent to adding two terms to the loss.
 
 # Parameters
 - Weight decay (`λ ≥ 0`): Controls the strength of the regularisation.
@@ -607,6 +608,8 @@ end
 
 Restricts every gradient component to obey `-δ ≤ dx[i] ≤ δ`.
 
+Typically composed with other rules using [`OptimiserChain`](@ref).
+
 See also [`ClipNorm`](@ref).
 """
 @def struct ClipGrad <: AbstractRule
@@ -630,6 +633,8 @@ to stay at this threshold (unless `p==0`).
 
 Throws an error if the norm is infinite or `NaN`,
 which you can turn off with `throw = false`.
+
+Typically composed with other rules using [`OptimiserChain`](@ref).
 
 See also [`ClipGrad`](@ref).
 """

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -596,7 +596,7 @@ function adjust(r::WeightDecay; gamma = nothing, kw...)
   if isnothing(gamma)
     return _adjust(r, NamedTuple(kw))
   else
-    Base.depwarn("The strength of WeightDecay is now field :lambda, not :gamma", :adjust, force=true)
+    Base.depwarn("The strength of WeightDecay is now field :lambda, not :gamma", :adjust)
     nt = (; lambda = gamma, NamedTuple(kw)...)
     return _adjust(r, nt)
   end

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -549,7 +549,7 @@ It does this by adding `λ .* x` to the gradient. This is equivalent to adding
 See also [`SignDecay`] for ``L_1`` normalisation.
 
 # Parameters
-- Weight decay (`λ ≥ 0`): Controls the strength of the regularisation.
+- Penalty (`λ ≥ 0`): Controls the strength of the regularisation.
 """
 @def struct WeightDecay <: AbstractRule
   lambda = 5e-4
@@ -563,6 +563,16 @@ function apply!(o::WeightDecay, state, x::AbstractArray{T}, dx) where T
 
   return state, dx′
 end
+
+function adjust(r::WeightDecay; gamma = nothing, kw...)
+   if isnothing(gamma)
+     return _adjust(r, NamedTuple(kw))
+   else
+     Base.depwarn("The strength of WeightDecay is now field :lambda, not :gamma", :adjust, force=true)
+     nt = (; lambda = gamma, NamedTuple(kw)...)
+     return _adjust(r, nt)
+   end
+ end
 
 """
     SignDecay(κ = 1e-3)

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -575,30 +575,30 @@ function adjust(r::WeightDecay; gamma = nothing, kw...)
  end
 
 """
-    SignDecay(κ = 1e-3)
+    SignDecay(λ = 1e-3)
 
 Implements ``L_1`` regularisation, also known as LASSO regression,
 when composed  with other rules as the first transformation in an [`OptimiserChain`](@ref).
 
-It does this by adding `κ .* sign(x)` to the gradient. This is equivalent to adding 
-`κ * sum(abs, x) == κ * norm(x, 1)` to the loss.
+It does this by adding `λ .* sign(x)` to the gradient. This is equivalent to adding 
+`λ * sum(abs, x) == λ * norm(x, 1)` to the loss.
 
 See also [`WeightDecay`] for ``L_2`` normalisation.
 They can be used together: `OptimiserChain(SignDecay(0.012), WeightDecay(0.034), Adam())`
 is equivalent to adding `0.012 * norm(x, 1) + 0.017 * norm(x, 2)^2` to the loss function.
 
 # Parameters
-- Penalty (`κ ≥ 0`): Controls the strength of the regularisation.
+- Penalty (`λ ≥ 0`): Controls the strength of the regularisation.
 """
 @def struct SignDecay <: AbstractRule
-  kappa = 1e-3
+  lambda = 1e-3
 end
 
 init(o::SignDecay, x::AbstractArray) = nothing
 
 function apply!(o::SignDecay, state, x::AbstractArray{T}, dx) where T
-  κ = T(o.kappa)
-  dx′ = @lazy dx + κ * sign(x)
+  λ = T(o.lambda)
+  dx′ = @lazy dx + λ * sign(x)
 
   return state, dx′
 end

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -565,28 +565,30 @@ function apply!(o::WeightDecay, state, x::AbstractArray{T}, dx) where T
 end
 
 """
-    SignDecay(λ = 1e-3)
+    SignDecay(κ = 1e-3)
 
 Implements ``L_1`` regularisation, also known as LASSO regression,
 when composed  with other rules as the first transformation in an [`OptimiserChain`](@ref).
 
-It does this by adding `λ .* sign(x)` to the gradient. This is equivalent to adding 
-`λ * sum(abs, x) == λ * norm(x, 1)` to the loss.
+It does this by adding `κ .* sign(x)` to the gradient. This is equivalent to adding 
+`κ * sum(abs, x) == κ * norm(x, 1)` to the loss.
 
 See also [`WeightDecay`] for ``L_2`` normalisation.
+They can be used together: `OptimiserChain(SignDecay(0.012), WeightDecay(0.034), Adam())`
+is equivalent to adding `0.012 * norm(x, 1) + 0.017 * norm(x, 2)^2` to the loss function.
 
 # Parameters
-- Sign decay (`λ ≥ 0`): Controls the strength of the regularisation.
+- Penalty (`κ ≥ 0`): Controls the strength of the regularisation.
 """
 @def struct SignDecay <: AbstractRule
-  lambda = 1e-3
+  kappa = 1e-3
 end
 
 init(o::SignDecay, x::AbstractArray) = nothing
 
 function apply!(o::SignDecay, state, x::AbstractArray{T}, dx) where T
-  λ = T(o.lambda)
-  dx′ = @lazy dx + λ * sign(x)
+  κ = T(o.kappa)
+  dx′ = @lazy dx + κ * sign(x)
 
   return state, dx′
 end

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -487,7 +487,7 @@ function apply!(o::NAdam, state, x::AbstractArray{T}, dx) where T
 end
 
 """
-    AdamW(η = 0.001, β = (0.9, 0.999), γ = 0, ϵ = 1e-8)
+    AdamW(η = 0.001, β = (0.9, 0.999), λ = 0, ϵ = 1e-8)
 
 [AdamW](https://arxiv.org/abs/1711.05101) is a variant of Adam fixing (as in repairing) its
 weight decay regularization.
@@ -538,51 +538,26 @@ function apply!(o::AdaBelief, state, x::AbstractArray{T}, dx) where T
 end
 
 """
-    WeightDecay(λ = 5e-4, α = 0)
+    WeightDecay(λ = 5e-4)
 
-Implements two forms of regularisation, when composed  with other rules
-as the first transformation in an [`OptimiserChain`](@ref):
+Implements ``L_2`` regularisation, when composed  with other rules
+as the first transformation in an [`OptimiserChain`](@ref).
 
-* At ` α== 0`, it decays weights by ``λ``, that is, adds `λ .* x` to the
-  gradient ``x̄ = ∂ℓ/∂x`` which will then be subtracted from `x`. 
-  This implements ``L_2`` regularisation: it is precisely the gradient of 
-  `λ/2 * sum(abs2, x)`, so is equivalent to adding this penaly to the loss
-  function ``ℓ`` (for every parameter array `x`).
+It does this by adding `2 .* x` to the gradient. This is equivalent to adding 
+`λ/2 * sum(abs2, x) == λ/2 * norm(x)^2` to the loss.
 
-* At `α == 1`, adds `λ .* sign.(x)` to the gradient. This implements ``L_1``
-  regularisation, equivalent to adding `λ * sum(abs, x)` (which is `λ * norm(x, 1)`)
-  to the loss.
-
-In general, it adds `@. λ * (1-α) * x + λ * α * sign(x)` to the gradient, thus implementing
-a mixture of the two effects, equivalent to adding two terms to the loss.
+And also equivalent to [`NormReg`](@ref)`(λ/2, 0)`.
+This struct's convention of what `λ` means is the one used in most machine learning frameworks,
+while [`NormReg`] matches that used for ``L_1`` in other contexts.
 
 # Parameters
 - Weight decay (`λ ≥ 0`): Controls the strength of the regularisation.
-- Mixture (`0 ≤ α ≤ 1`): Controls the proportion of ``L_1`` regularisation, zero by default.
-
-# Example
-```jldoctest
-julia> rule = OptimiserChain(WeightDecay(), Momentum());
-
-julia> opt_state = Optimisers.setup(rule, (weight = [1.0],))
-(weight = Leaf(OptimiserChain(WeightDecay(0.0005, 0.0), Momentum(0.01, 0.9)), (nothing, [0.0])),)
-
-julia> Optimisers.adjust!(opt_state, alpha=0.5)  # replace L2 with a mix of L1 and L2
-
-julia> opt_state
-(weight = Leaf(OptimiserChain(WeightDecay(0.0005, 0.5), Momentum(0.01, 0.9)), (nothing, [0.0])),)
-```
 """
 @def struct WeightDecay <: AbstractRule
   lambda = 5e-4
-  alpha = 0.0
 end
 
-function init(o::WeightDecay, x::AbstractArray)
-  o.lambda ≥ 0 || throw(DomainError())
-  0 ≤ o.alpha ≤ 1 || throw(DomainError())
-  return nothing
-end
+init(o::WeightDecay, x::AbstractArray) = nothing
 
 function apply!(o::WeightDecay, state, x::AbstractArray{T}, dx) where T
   λ, α = T(o.lambda), T(o.alpha)
@@ -593,14 +568,60 @@ function apply!(o::WeightDecay, state, x::AbstractArray{T}, dx) where T
   return state, dx′
 end
 
-function adjust(r::WeightDecay; gamma = nothing, kw...)
-  if isnothing(gamma)
-    return _adjust(r, NamedTuple(kw))
-  else
-    Base.depwarn("The strength of WeightDecay is now field :lambda, not :gamma", :adjust)
-    nt = (; lambda = gamma, NamedTuple(kw)...)
-    return _adjust(r, nt)
-  end
+"""
+    NormReg(λ = 0.001, α = 1)
+
+Implements ``L_1`` and ``L_2`` regularisation, when composed  with other rules
+as the first transformation in an [`OptimiserChain`](@ref).
+
+* At `α == 1` (the default), it adds `λ .* sign.(x)` to the gradient.
+  This is equivalent to adding `λ * sum(abs, x) == λ * norm(x, 1)`
+  to the loss (for every parameter array `x`), which is known as
+  L1 regularisation, or LASSO regression.
+
+* At `α == 0`, instead adds `2λ .* x` to the gradient. This is equivalen to adding 
+  `λ * sum(abs2, x) == λ * norm(x)^2` to the loss, known as L2 regularisation, or ridge regression.
+  This is equivelent to [`WeightDecay`](@ref)`(2λ)`.
+
+At intermediate `α`, it adds `@. λ * (α*sign(x) + 2(1-α)*x)` to the gradient, thus implementing
+a mixture of the two effects, equivalent to adding two penalty terms to the loss.
+
+# Parameters
+- Weight decay (`λ ≥ 0`): Controls the strength of the regularisation.
+- Mixture (`0 ≤ α ≤ 1`): Controls the proportion of ``L_1`` regularisation.
+
+# Example
+```jldoctest
+julia> rule = OptimiserChain(NormReg(), Momentum());
+
+julia> opt_state = Optimisers.setup(rule, (weight = [1.0],))
+(weight = Leaf(OptimiserChain(NormReg(0.0005, 1.0), Momentum(0.01, 0.9)), (nothing, [0.0])),)
+
+julia> Optimisers.adjust!(opt_state, alpha=0.5)  # replace L1 with a mix of L1 and L2
+
+julia> opt_state
+(weight = Leaf(OptimiserChain(NormReg(0.0005, 0.5), Momentum(0.01, 0.9)), (nothing, [0.0])),)
+```
+"""
+@def struct NormReg <: AbstractRule
+  lambda = 1e-3
+  alpha = 1.0
+end
+
+function init(o::NormReg, x::AbstractArray)
+  o.lambda ≥ 0 || throw(DomainError("NormReg does not allow a negative strength"))
+  0 ≤ o.alpha ≤ 1 || throw(DomainError("NormReg's mixture parameter must be between 0 and 1"))
+  return nothing
+end
+
+function apply!(o::NormReg, state, x::AbstractArray{T}, dx) where T
+  λ, α = T(o.lambda), T(o.alpha)
+
+  ℓ1 = λ * α
+  ℓ2 = 2 * λ * (1 - α)
+  dx′ = @lazy dx + ℓ2 * x + ℓ1 * sign(x)
+
+  return state, dx′
 end
 
 """

--- a/test/rules.jl
+++ b/test/rules.jl
@@ -10,7 +10,7 @@ RULES = [
   AdaGrad(), AdaMax(), AdaDelta(), AMSGrad(), NAdam(),
   AdamW(), RAdam(), OAdam(), AdaBelief(), Lion(),
   # A few chained combinations:
-  OptimiserChain(WeightDecay(0.0001, 0.5), Adam(0.001)),
+  OptimiserChain(NormReg(0.0001, 0.5), Adam(0.001)),
   OptimiserChain(ClipNorm(), Adam(0.001)),
   OptimiserChain(ClipGrad(0.5), Momentum()),
   OptimiserChain(WeightDecay(), OAdam(), ClipGrad(1)),

--- a/test/rules.jl
+++ b/test/rules.jl
@@ -10,7 +10,7 @@ RULES = [
   AdaGrad(), AdaMax(), AdaDelta(), AMSGrad(), NAdam(),
   AdamW(), RAdam(), OAdam(), AdaBelief(), Lion(),
   # A few chained combinations:
-  OptimiserChain(WeightDecay(), Adam(0.001)),
+  OptimiserChain(WeightDecay(0.005, 0.5), Adam(0.001)),
   OptimiserChain(ClipNorm(), Adam(0.001)),
   OptimiserChain(ClipGrad(0.5), Momentum()),
   OptimiserChain(WeightDecay(), OAdam(), ClipGrad(1)),

--- a/test/rules.jl
+++ b/test/rules.jl
@@ -10,7 +10,7 @@ RULES = [
   AdaGrad(), AdaMax(), AdaDelta(), AMSGrad(), NAdam(),
   AdamW(), RAdam(), OAdam(), AdaBelief(), Lion(),
   # A few chained combinations:
-  OptimiserChain(NormReg(0.0001, 0.5), Adam(0.001)),
+  OptimiserChain(SignDecay(0.001), Adam(0.001)),
   OptimiserChain(ClipNorm(), Adam(0.001)),
   OptimiserChain(ClipGrad(0.5), Momentum()),
   OptimiserChain(WeightDecay(), OAdam(), ClipGrad(1)),

--- a/test/rules.jl
+++ b/test/rules.jl
@@ -10,7 +10,7 @@ RULES = [
   AdaGrad(), AdaMax(), AdaDelta(), AMSGrad(), NAdam(),
   AdamW(), RAdam(), OAdam(), AdaBelief(), Lion(),
   # A few chained combinations:
-  OptimiserChain(WeightDecay(0.005, 0.5), Adam(0.001)),
+  OptimiserChain(WeightDecay(0.0001, 0.5), Adam(0.001)),
   OptimiserChain(ClipNorm(), Adam(0.001)),
   OptimiserChain(ClipGrad(0.5), Momentum()),
   OptimiserChain(WeightDecay(), OAdam(), ClipGrad(1)),

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -137,6 +137,7 @@ end
     @testset "OptimiserChain" begin
       x = [1, 10, 100.0]; dx = [1, 2, 3.0];
       @test Optimisers.update(Optimisers.setup(WeightDecay(0.1), x), x, dx)[2] ≈ [1-0.1-1, 10-1-2, 100-10-3]
+      @test Optimisers.update(Optimisers.setup(WeightDecay(0.1, 1), x), x, dx)[2] ≈ [1-0.1-1, 10-0.1-2, 100-0.1-3]
       @test Optimisers.update(Optimisers.setup(ClipGrad(2), x), x, dx)[2] ≈ [1-1, 10-2, 100-2]
 
       o2 = OptimiserChain(ClipGrad(2), WeightDecay(0.1))
@@ -154,6 +155,10 @@ end
 
       o0 = OptimiserChain()
       @test Optimisers.update(Optimisers.setup(o0, x), x, dx)[2] ≈ [1-1,10-2,100-3]
+
+      # L1 norm via sign
+      xm = [1, -10, 100.0]; dxm = [3, 2, -1];
+      @test Optimisers.update(Optimisers.setup(WeightDecay(0.1, 1), xm), xm, dxm)[2] ≈ [1-0.1-3, -10+0.1-2, 100-0.1+1]
     end
 
     @testset "trainable subset" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -137,7 +137,7 @@ end
     @testset "OptimiserChain" begin
       x = [1, 10, 100.0]; dx = [1, 2, 3.0];
       @test Optimisers.update(Optimisers.setup(WeightDecay(0.1), x), x, dx)[2] ≈ [1-0.1-1, 10-1-2, 100-10-3]
-      @test Optimisers.update(Optimisers.setup(NormReg(0.1, 1), x), x, dx)[2] ≈ [1-0.1-1, 10-0.1-2, 100-0.1-3]
+      @test Optimisers.update(Optimisers.setup(SignDecay(0.1), x), x, dx)[2] ≈ [1-0.1-1, 10-0.1-2, 100-0.1-3]
       @test Optimisers.update(Optimisers.setup(ClipGrad(2), x), x, dx)[2] ≈ [1-1, 10-2, 100-2]
 
       o2 = OptimiserChain(ClipGrad(2), WeightDecay(0.1))
@@ -158,7 +158,7 @@ end
 
       # L1 norm via sign
       xm = [1, -10, 100.0]; dxm = [3, 2, -1];
-      @test Optimisers.update(Optimisers.setup(NormReg(0.1, 1), xm), xm, dxm)[2] ≈ [1-0.1-3, -10+0.1-2, 100-0.1+1]
+      @test Optimisers.update(Optimisers.setup(SignDecay(0.1), xm), xm, dxm)[2] ≈ [1-0.1-3, -10+0.1-2, 100-0.1+1]
     end
 
     @testset "trainable subset" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -137,7 +137,7 @@ end
     @testset "OptimiserChain" begin
       x = [1, 10, 100.0]; dx = [1, 2, 3.0];
       @test Optimisers.update(Optimisers.setup(WeightDecay(0.1), x), x, dx)[2] ≈ [1-0.1-1, 10-1-2, 100-10-3]
-      @test Optimisers.update(Optimisers.setup(WeightDecay(0.1, 1), x), x, dx)[2] ≈ [1-0.1-1, 10-0.1-2, 100-0.1-3]
+      @test Optimisers.update(Optimisers.setup(NormReg(0.1, 1), x), x, dx)[2] ≈ [1-0.1-1, 10-0.1-2, 100-0.1-3]
       @test Optimisers.update(Optimisers.setup(ClipGrad(2), x), x, dx)[2] ≈ [1-1, 10-2, 100-2]
 
       o2 = OptimiserChain(ClipGrad(2), WeightDecay(0.1))
@@ -158,7 +158,7 @@ end
 
       # L1 norm via sign
       xm = [1, -10, 100.0]; dxm = [3, 2, -1];
-      @test Optimisers.update(Optimisers.setup(WeightDecay(0.1, 1), xm), xm, dxm)[2] ≈ [1-0.1-3, -10+0.1-2, 100-0.1+1]
+      @test Optimisers.update(Optimisers.setup(NormReg(0.1, 1), xm), xm, dxm)[2] ≈ [1-0.1-3, -10+0.1-2, 100-0.1+1]
     end
 
     @testset "trainable subset" begin


### PR DESCRIPTION
As I learned here https://github.com/FluxML/MLJFlux.jl/issues/221#issuecomment-1707604760 , since the gradient of L1 norm is even simpler than the gradient of L2 norm it can, obviously, be implemented as an optimisation rule.

This quick PR adds it to the same WeightDecay struct. Below is a check that this does what you expect.

<details>

```julia
using Flux: Flux, Dense, gradient, state
using Optimisers
using Optimisers: setup, update

input = [1,2]
model = Dense([1 -2; 3 -4.0])

grads = Flux.gradient(model) do m
  result = m(input)
  sum(result)
end

# Check L2 norm via WeightDecay (nothing new!)

pen_l2(x::AbstractArray) = sum(abs2, x)/2

grads_L2 = Flux.gradient(model) do m
  result = m(input)
  penalty = sum(pen_l2, Flux.params(m))
  sum(result) + 0.42 * penalty
end

update(
  setup(Descent(0.1), model),
  model, grads_L2[1])[2] |> Flux.state

update(
  setup(OptimiserChain(WeightDecay(0.42), Descent(0.1)), model),
  model, grads[1])[2] |> Flux.state

# Do exactly the same thing for L1 (needs this PR)

pen_l1(x::AbstractArray) = sum(abs, x)

grads_L1 = Flux.gradient(model) do m
  result = m(input)
  penalty = sum(pen_l1, Flux.params(m))
  sum(result) + 0.42 * penalty
end

update(
  setup(Descent(0.1), model),
  model, grads_L1[1])[2] |> Flux.state

update(
  setup(OptimiserChain(WeightDecay(0.0, 0.42), Descent(0.1)), model),
  model, grads[1])[2] |> Flux.state
  
# Both give (weight = [0.858 -2.158; 2.858 -4.158], bias = [-0.1, -0.1], σ = ())
```

</details>

### PR Checklist

- [x] Tests are added
- [x] Documentation, if applicable
