### PR TITLE
add `trainables`

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -58,6 +58,7 @@ Such restrictions are also obeyed by this function for flattening a model:
 ```@docs
 Optimisers.destructure
 Optimisers.Restructure
+Optimisers.trainables
 ```
 
 ## Rule Definition

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -290,3 +290,29 @@ flat, re = destructure(params)
 end
 ```
 
+## Collecting all trainable parameters
+
+Sometimes it is useful to collect all trainable parameters in a model,
+similarly to what [`destructure`](@ref Optimisers.destructure) does but keeping
+the arrays separate. 
+This is done by [`trainables`](@ref Optimisers.trainables), which returns a list of arrays:
+
+```julia
+julia> using Flux, Optimisers
+
+julia> model = Chain(Dense(2 => 3, tanh), BatchNorm(3), Dense(3 => 2));
+
+julia> trainables(model)
+6-element Vector{AbstractArray}:
+ Float32[0.5756773 -0.1975264; 0.4723181 -0.7546912; -0.91631395 0.07392061]
+ Float32[0.0, 0.0, 0.0]
+ Float32[0.0, 0.0, 0.0]
+ Float32[1.0, 1.0, 1.0]
+ Float32[-0.8764882 0.40812716 0.1919528; -0.9123545 -0.4462516 0.6751252]
+ Float32[0.0, 0.0]
+
+julia> l2reg(model) = sum([sum(abs2,p) for p in trainables(model)]);
+
+julia> g = gradient(l2reg, model)[1];
+```
+Notice that the `BatchNorm` layer has two trainable parameters, `γ` and `β`, which are included in the list, while the `μ ` and `σ²` buffers are not.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -293,8 +293,8 @@ end
 ## Collecting all trainable parameters
 
 Sometimes it is useful to collect all trainable parameters in a model,
-similarly to what [`destructure`](@ref Optimisers.destructure) does but keeping
-the arrays separate. 
+similarly to what [`destructure`](@ref Optimisers.destructure) does but without
+concatenating the arrays into a flat vector.
 This is done by [`trainables`](@ref Optimisers.trainables), which returns a list of arrays:
 
 ```julia

--- a/src/Optimisers.jl
+++ b/src/Optimisers.jl
@@ -11,6 +11,9 @@ include("adjust.jl")
 include("destructure.jl")
 export destructure
 
+include("trainables.jl")
+export trainables
+
 include("rules.jl")
 export Descent, Adam, Momentum, Nesterov, Rprop, RMSProp,
        AdaGrad, AdaMax, AdaDelta, AMSGrad, NAdam, AdamW, RAdam, OAdam, AdaBelief,

--- a/src/destructure.jl
+++ b/src/destructure.jl
@@ -73,7 +73,7 @@ function _flatten(x)
     o
   end
   isempty(arrays) && return Bool[], off, 0
-  reduce(vcat, arrays), off, len[]
+  return reduce(vcat, arrays), off, len[]
 end
 
 struct _TrainableStructWalk <: AbstractWalk end
@@ -174,3 +174,4 @@ function ChainRulesCore.rrule(::typeof(_maybewarn))
   @warn "second derivatives of destructure may not work yet, sorry!" maxlog=3
   nothing, _ -> (NoT,)
 end
+

--- a/src/destructure.jl
+++ b/src/destructure.jl
@@ -66,7 +66,7 @@ function _flatten(x)
   isnumeric(x) && return vcat(_vec(x)), 0, length(x)  # trivial case
   arrays = AbstractVector[]
   len = Ref(0)
-  off = fmap(x; exclude = isnumeric, walk = _TrainableStructWalk()) do y
+  off = fmap(x; exclude = isnumeric, walk = TrainableStructWalk()) do y
     push!(arrays, _vec(y))
     o = len[]
     len[] = o + length(y)
@@ -76,9 +76,9 @@ function _flatten(x)
   return reduce(vcat, arrays), off, len[]
 end
 
-struct _TrainableStructWalk <: AbstractWalk end
+struct TrainableStructWalk <: AbstractWalk end
 
-(::_TrainableStructWalk)(recurse, x) = map(recurse, _trainable(x))
+(::TrainableStructWalk)(recurse, x) = map(recurse, _trainable(x))
 
 _vec(x::Number) = LinRange(x,x,1)
 _vec(x::AbstractArray) = vec(x)

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -167,6 +167,7 @@ and `trainable(x)` must contain a subset of these.
 """
 trainable(x) = functor(x)[1]
 
+# like trainable(x), but also tries to output non-trainable children giving value nothing
 _trainable(x) = _trainable(functor(x)[1], trainable(x))
 _trainable(ch::NamedTuple, tr::NamedTuple) = merge(map(_ -> nothing, ch), tr)
 _trainable(ch::Tuple{Vararg{Any,N}}, tr::Tuple{Vararg{Any,N}}) where N = tr

--- a/src/trainables.jl
+++ b/src/trainables.jl
@@ -2,16 +2,31 @@ using BenchmarkTools
 using Optimisers
 using Functors
 using Zygote, Flux
+using ChainRulesCore
 
 function trainables1(x)
-    Optimisers.isnumeric(x) && return [x]
     arrays = AbstractArray[]
-    exclude(x) = Optimisers.isnumeric(x) && Functors.isleaf(x)
+    exclude(x) = Optimisers.isnumeric(x)
     fmap(x; exclude, walk = Optimisers._TrainableStructWalk()) do y
         push!(arrays, y)
         return y
     end
     return arrays
+end
+
+function ∇trainables1(x, Δ)
+    exclude(x) = Optimisers.isnumeric(x)
+    i = 0
+    return fmapstructure(x; exclude, walk = Optimisers._TrainableStructWalk()) do _
+                return Δ[i+=1]
+           end
+end
+
+
+function ChainRulesCore.rrule(::typeof(trainables1), x)
+    y = trainables1(x)
+    trainables_back(Δ) = (NoTangent(), ∇trainables1(x, unthunk(Δ)))
+    return y, trainables_back
 end
 
 ############
@@ -49,7 +64,7 @@ end
 
 
 function floss(ps)
-    sum([sum(p) for p in ps])
+    sum([sum(abs2, p) for p in ps])
 end
 
 using Flux
@@ -57,25 +72,44 @@ using Flux
 function perf()
     m = Chain(Dense(128 => 128, relu), 
               Dense(128 => 128, relu),
-              BatchNorm(128), Dense(3 => 2), x -> x^2)
+              BatchNorm(128),
+              x -> x^2,
               Dense(128 => 128, relu), 
-              Dense(128 => 128, relu)
+              Dense(128 => 128, relu))
               
     println("trainables1")
-    @btime trainables1($m)
+    @btime floss(trainables1($m))
     println("trainables2")
-    @btime trainables2($m)
+    @btime floss(trainables2($m))
     println("trainables3")
-    @btime trainables3($m)
+    @btime floss(trainables3($m))
     println()
 
-
-    # gradient(m -> floss(trainables1(m)), #m) # non differentiable since mutating
+    println("gradient trainables1")
+    @btime gradient(m -> floss(trainables1(m)), $m)
     println("gradient trainables2")
     @btime gradient(m -> floss(trainables2(m)), $m)
     println("gradient trainables3")
     @btime gradient(m -> floss(trainables3(m)), $m)
+
+    nothing
 end
 
 Zygote.refresh()
 perf()
+
+
+m = Chain(Dense(128 => 128, relu), 
+              Dense(128 => 128, relu),
+              BatchNorm(128),
+              x -> x^2,
+              Dense(128 => 128, relu), 
+              Dense(128 => 128, relu))
+              
+floss(trainables1(m))
+g1 = gradient(m -> floss(trainables1(m)), m)[1]
+g2 = gradient(m -> floss(trainables2(m)), m)[1]
+@test g1.layers[1].weight ≈ g2.layers[1].weight
+@test g1.layers[1].weight ≈ g2.layers[1].weight
+@test g1.layers[3].μ === nothing
+@test g2.layers[3].μ === nothing

--- a/src/trainables.jl
+++ b/src/trainables.jl
@@ -2,7 +2,7 @@
 """
     trainables(x)
 
-Return an iterable over all the trainable parameters in `x`, that is all the numerical
+Return a list over all the trainable parameters in `x`, that is all the numerical
 arrays (see [`isnumeric`](@ref Optimisers.isnumeric)) which are reachable through [`trainable`](@ref Optimisers.trainable).
 
 Parameters appearing multiple times in the model (tied weights) will be present only once in the output.

--- a/src/trainables.jl
+++ b/src/trainables.jl
@@ -5,9 +5,9 @@
 Return an iterable over all the trainable parameters in `x`, that is all the numerical
 arrays (see [`isnumeric`](@ref Optimisers.isnumeric)) which are reachable through [`trainable`](@ref Optimisers.trainable).
 
-Parameters appearing multiple times in the model will be present only once in the output.
+Parameters appearing multiple times in the model (tied weights) will be present only once in the output.
 
-See also [`destructure`](@ref).
+See also [`destructure`](@ref) for a similar operation that returns a single flat vector instead.
 
 # Examples
 
@@ -26,6 +26,13 @@ julia> x = MyLayer([1.0,2.0,3.0], [4.0,5.0,6.0]);
 julia> trainables(x)
 1-element Vector{AbstractArray}:
  [1.0, 2.0, 3.0]
+
+ julia> x = MyLayer((a=[1.0,2.0], b=[3.0]), [4.0,5.0,6.0]);
+
+ julia> trainables(x) # collects nested parameters
+ 2-element Vector{AbstractArray}:
+ [1.0, 2.0]
+ [3.0]
 """
 function trainables(x)
     arrays = AbstractArray[]
@@ -40,7 +47,7 @@ end
 function ∇trainables(x, Δ)
     exclude(x) = Optimisers.isnumeric(x)
     i = 0
-    return fmapstructure(x; exclude, walk = Optimisers.TrainableStructWalk()) do _
+    return fmapstructure(x; exclude, walk = TrainableStructWalk()) do _
                 return Δ[i+=1]
            end
 end

--- a/src/trainables.jl
+++ b/src/trainables.jl
@@ -1,9 +1,13 @@
-
+using BenchmarkTools
+using Optimisers
+using Functors
+using Zygote, Flux
 
 function trainables1(x)
-    isnumeric(x) && return [x]
+    Optimisers.isnumeric(x) && return [x]
     arrays = AbstractArray[]
-    fmap(x; exclude = isnumeric, walk = _TrainableStructWalk()) do y
+    exclude(x) = Optimisers.isnumeric(x) && Functors.isleaf(x)
+    fmap(x; exclude, walk = Optimisers._TrainableStructWalk()) do y
         push!(arrays, y)
         return y
     end
@@ -17,19 +21,61 @@ using Functors: AbstractWalk, _map, _values, execute, ExcludeWalk
 struct TrainableWalk2 <: AbstractWalk end
 
 function (walk::TrainableWalk2)(recurse, x, ys...)
-    x_children = _values(Optimisers.trainable(x))
+    x_children = Optimisers.trainable(x)
     ys_children = map(Optimisers.trainable, ys)
-    res = _map(recurse, x_children, ys_children...)
-    @show _values(res)
-    return _values(res)
+    res = map(recurse, x_children, ys_children...)
+    return reduce(vcat, values(res),init=[])
 end
 
 function trainables2(x)
     exclude(x) = Optimisers.isnumeric(x) && Functors.isleaf(x)
-    return execute(ExcludeWalk(TrainableWalk2(), x -> x, exclude), x)
+    return execute(ExcludeWalk(TrainableWalk2(), x ->[x], exclude), x)
+end
+
+
+struct TrainableWalk3 <: AbstractWalk end
+
+function (walk::TrainableWalk3)(recurse, x, ys...)
+    x_children = Optimisers.trainable(x)
+    ys_children = map(Optimisers.trainable, ys)
+    res = map(recurse, x_children, ys_children...)
+    return vcat(values(res)...)
+end
+
+function trainables3(x)
+    exclude(x) = Optimisers.isnumeric(x)
+    return execute(ExcludeWalk(TrainableWalk3(), x ->[x], exclude), x)
+end
+
+
+function floss(ps)
+    sum([sum(p) for p in ps])
 end
 
 using Flux
 
-m = Chain(Dense(2 => 3, relu), BatchNorm(3), Dense(3 => 2))
-trainables2(m)
+function perf()
+    m = Chain(Dense(128 => 128, relu), 
+              Dense(128 => 128, relu),
+              BatchNorm(128), Dense(3 => 2), x -> x^2)
+              Dense(128 => 128, relu), 
+              Dense(128 => 128, relu)
+              
+    println("trainables1")
+    @btime trainables1($m)
+    println("trainables2")
+    @btime trainables2($m)
+    println("trainables3")
+    @btime trainables3($m)
+    println()
+
+
+    # gradient(m -> floss(trainables1(m)), #m) # non differentiable since mutating
+    println("gradient trainables2")
+    @btime gradient(m -> floss(trainables2(m)), $m)
+    println("gradient trainables3")
+    @btime gradient(m -> floss(trainables3(m)), $m)
+end
+
+Zygote.refresh()
+perf()

--- a/src/trainables.jl
+++ b/src/trainables.jl
@@ -1,115 +1,52 @@
-using BenchmarkTools
-using Optimisers
-using Functors
-using Zygote, Flux
-using ChainRulesCore
 
-function trainables1(x)
+"""
+    trainables(x)
+
+Return an iterable over all the trainable parameters in `x`, that is all the numerical
+arrays (see [`isnumeric`](@ref Optimisers.isnumeric)) which are reachable through [`trainable`](@ref Optimisers.trainable).
+
+Parameters appearing multiple times in the model will be present only once in the output.
+
+See also [`destructure`](@ref).
+
+# Examples
+
+```jldoctest
+julia> struct MyLayer
+         w
+         b
+       end
+
+julia> Functors.@functor MyLayer
+
+julia> Optimisers.trainable(x::MyLayer) = (; w = x.w,) # only w is trainable in this example
+
+julia> x = MyLayer([1.0,2.0,3.0], [4.0,5.0,6.0]);
+
+julia> trainables(x)
+1-element Vector{AbstractArray}:
+ [1.0, 2.0, 3.0]
+"""
+function trainables(x)
     arrays = AbstractArray[]
     exclude(x) = Optimisers.isnumeric(x)
-    fmap(x; exclude, walk = Optimisers._TrainableStructWalk()) do y
+    fmap(x; exclude, walk = Optimisers.TrainableStructWalk()) do y
         push!(arrays, y)
         return y
     end
     return arrays
 end
 
-function ∇trainables1(x, Δ)
+function ∇trainables(x, Δ)
     exclude(x) = Optimisers.isnumeric(x)
     i = 0
-    return fmapstructure(x; exclude, walk = Optimisers._TrainableStructWalk()) do _
+    return fmapstructure(x; exclude, walk = Optimisers.TrainableStructWalk()) do _
                 return Δ[i+=1]
            end
 end
 
-
-function ChainRulesCore.rrule(::typeof(trainables1), x)
-    y = trainables1(x)
-    trainables_back(Δ) = (NoTangent(), ∇trainables1(x, unthunk(Δ)))
+function ChainRulesCore.rrule(::typeof(trainables), x)
+    y = trainables(x)
+    trainables_back(Δ) = (NoTangent(), ∇trainables(x, unthunk(Δ)))
     return y, trainables_back
 end
-
-############
-
-using Functors: AbstractWalk, _map, _values, execute, ExcludeWalk
-
-struct TrainableWalk2 <: AbstractWalk end
-
-function (walk::TrainableWalk2)(recurse, x, ys...)
-    x_children = Optimisers.trainable(x)
-    ys_children = map(Optimisers.trainable, ys)
-    res = map(recurse, x_children, ys_children...)
-    return reduce(vcat, values(res),init=[])
-end
-
-function trainables2(x)
-    exclude(x) = Optimisers.isnumeric(x) && Functors.isleaf(x)
-    return execute(ExcludeWalk(TrainableWalk2(), x ->[x], exclude), x)
-end
-
-
-struct TrainableWalk3 <: AbstractWalk end
-
-function (walk::TrainableWalk3)(recurse, x, ys...)
-    x_children = Optimisers.trainable(x)
-    ys_children = map(Optimisers.trainable, ys)
-    res = map(recurse, x_children, ys_children...)
-    return vcat(values(res)...)
-end
-
-function trainables3(x)
-    exclude(x) = Optimisers.isnumeric(x)
-    return execute(ExcludeWalk(TrainableWalk3(), x ->[x], exclude), x)
-end
-
-
-function floss(ps)
-    sum([sum(abs2, p) for p in ps])
-end
-
-using Flux
-
-function perf()
-    m = Chain(Dense(128 => 128, relu), 
-              Dense(128 => 128, relu),
-              BatchNorm(128),
-              x -> x^2,
-              Dense(128 => 128, relu), 
-              Dense(128 => 128, relu))
-              
-    println("trainables1")
-    @btime floss(trainables1($m))
-    println("trainables2")
-    @btime floss(trainables2($m))
-    println("trainables3")
-    @btime floss(trainables3($m))
-    println()
-
-    println("gradient trainables1")
-    @btime gradient(m -> floss(trainables1(m)), $m)
-    println("gradient trainables2")
-    @btime gradient(m -> floss(trainables2(m)), $m)
-    println("gradient trainables3")
-    @btime gradient(m -> floss(trainables3(m)), $m)
-
-    nothing
-end
-
-Zygote.refresh()
-perf()
-
-
-m = Chain(Dense(128 => 128, relu), 
-              Dense(128 => 128, relu),
-              BatchNorm(128),
-              x -> x^2,
-              Dense(128 => 128, relu), 
-              Dense(128 => 128, relu))
-              
-floss(trainables1(m))
-g1 = gradient(m -> floss(trainables1(m)), m)[1]
-g2 = gradient(m -> floss(trainables2(m)), m)[1]
-@test g1.layers[1].weight ≈ g2.layers[1].weight
-@test g1.layers[1].weight ≈ g2.layers[1].weight
-@test g1.layers[3].μ === nothing
-@test g2.layers[3].μ === nothing

--- a/src/trainables.jl
+++ b/src/trainables.jl
@@ -1,0 +1,35 @@
+
+
+function trainables1(x)
+    isnumeric(x) && return [x]
+    arrays = AbstractArray[]
+    fmap(x; exclude = isnumeric, walk = _TrainableStructWalk()) do y
+        push!(arrays, y)
+        return y
+    end
+    return arrays
+end
+
+############
+
+using Functors: AbstractWalk, _map, _values, execute, ExcludeWalk
+
+struct TrainableWalk2 <: AbstractWalk end
+
+function (walk::TrainableWalk2)(recurse, x, ys...)
+    x_children = _values(Optimisers.trainable(x))
+    ys_children = map(Optimisers.trainable, ys)
+    res = _map(recurse, x_children, ys_children...)
+    @show _values(res)
+    return _values(res)
+end
+
+function trainables2(x)
+    exclude(x) = Optimisers.isnumeric(x) && Functors.isleaf(x)
+    return execute(ExcludeWalk(TrainableWalk2(), x -> x, exclude), x)
+end
+
+using Flux
+
+m = Chain(Dense(2 => 3, relu), BatchNorm(3), Dense(3 => 2))
+trainables2(m)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,7 +10,7 @@ Random.seed!(1)
 
 struct Foo; x; y; end
 Functors.@functor Foo
-Optimisers.trainable(x::Foo) = (x.y, x.x)
+Optimisers.trainable(x::Foo) = (; x.y, x.x)
 
 struct TwoThirds a; b; c; end
 Functors.@functor TwoThirds (a, c)
@@ -538,6 +538,9 @@ end
   end
   @testset verbose=true "Destructure" begin
     include("destructure.jl")
+  end
+  @testset verbose=true "Trainables" begin
+    include("trainables.jl")
   end
   @testset verbose=true "Optimisation Rules" begin
     include("rules.jl")

--- a/test/trainables.jl
+++ b/test/trainables.jl
@@ -1,0 +1,99 @@
+
+m1 = collect(1:3.0)
+m2 = (collect(1:3.0), collect(4:6.0))
+m3 = (x = m1, y = sin, z = collect(4:6.0))
+
+m4 = (x = m1, y = m1, z = collect(4:6.0))  # tied
+m5 = (a = (m3, true), b = (m1, false), c = (m4, true))
+m6 = (a = m1, b = [4.0 + im], c = m1)
+
+m7 = TwoThirds((sin, collect(1:3.0)), (cos, collect(4:6.0)), (tan, collect(7:9.0)))
+m8 = [Foo(m1, m1), (a = true, b = Foo([4.0], false), c = ()), [[5.0]]]
+
+mat = Float32[4 6; 5 7]
+m9 = (a = m1, b = mat, c = [mat, m1])
+
+@testset "trainables" begin
+  ps = trainables(m1)
+  @test ps isa Vector
+  @test length(ps) == 1
+  @test ps[1] == m1
+
+  ps = trainables(m2)
+  @test ps isa Vector
+  @test length(ps) == 2
+  @test ps[1] == m2[1]
+  @test ps[2] == m2[2]
+
+  ps = trainables(m3)
+  @test length(ps) == 2
+  @test ps[1] == 1:3
+  @test ps[2] == 4:6
+
+  ps = trainables(m4)
+  @test length(ps) == 2
+  @test ps[1] == 1:3
+  @test ps[2] == 4:6
+  
+  ps = trainables(m5)
+  @test length(ps) == 3
+  @test ps[1] == 1:3
+  @test ps[2] == 4:6
+  @test ps[3] == 4:6
+
+  ps = trainables(m6)
+  @test length(ps) == 2
+  @test ps[1] == 1:3
+  @test ps[2] == ComplexF64[4.0 + 1.0im]
+
+  ps = trainables(m7)
+  @test length(ps) == 1
+  @test ps[1] == [1.0, 2.0, 3.0]
+
+  ps = trainables(m8)
+  @test length(ps) == 3
+  @test ps[1] == 1:3
+  @test ps[2] == [4.0]
+  @test ps[3] == [5.0]
+
+  ps = trainables(m9)
+  @test length(ps) == 2
+  @test ps[1] == 1:3
+  @test ps[2] == mat
+end
+
+@testset "gradient" begin
+  loss(m) = sum([sum(abs2, p) for p in trainables(m)])
+  g = gradient(loss, m1)[1]
+  @test g == [2.0, 4.0, 6.0]
+
+  g = gradient(loss, m2)[1]
+  @test g == ([2.0, 4.0, 6.0], [8.0, 10.0, 12.0])
+
+  g = gradient(loss, m3)[1]
+  @test g.x == [2.0, 4.0, 6.0]
+  @test g.y === nothing
+  @test g.z == [8.0, 10.0, 12.0]
+
+  g = gradient(loss, m4)[1]
+  @test g == (x = [2.0, 4.0, 6.0], y = [2.0, 4.0, 6.0], z = [8.0, 10.0, 12.0])
+  g.x === g.y # shared gradient for shared weights
+
+  g = gradient(loss, m5)[1]
+  @test g == (a = ((x = [2.0, 4.0, 6.0], y = nothing, z = [8.0, 10.0, 12.0]), nothing), b = ([2.0, 4.0, 6.0], nothing), c = ((x = [2.0, 4.0, 6.0], y = [2.0, 4.0, 6.0], z = [8.0, 10.0, 12.0]), nothing))
+  
+  g = gradient(loss, m6)[1]
+  @test g = (a = [2.0, 4.0, 6.0], b = ComplexF64[8.0 + 2.0im], c = [2.0, 4.0, 6.0])
+  
+  g = gradient(loss, m7)[1]
+  @test g == (a = (nothing, [2.0, 4.0, 6.0]), b = nothing, c = nothing)
+
+  g = gradient(loss, m8)[1]
+  @test g[1] == (x = [2.0, 4.0, 6.0], y = [2.0, 4.0, 6.0])
+  @test g[2] == (a = nothing, b = (x = [8.0], y = nothing), c = nothing)
+  @test g[3] == [[10.0]]
+
+  g = gradient(loss, m9)[1]
+  @test g == (a = [2.0, 4.0, 6.0], b = Float32[8.0 12.0; 10.0 14.0], c = Array[Float32[8.0 12.0; 10.0 14.0], [2.0, 4.0, 6.0]])
+end
+

--- a/test/trainables.jl
+++ b/test/trainables.jl
@@ -97,3 +97,19 @@ end
   @test g == (a = [2.0, 4.0, 6.0], b = Float32[8.0 12.0; 10.0 14.0], c = Array[Float32[8.0 12.0; 10.0 14.0], [2.0, 4.0, 6.0]])
 end
 
+@testset "second order derivatives" begin
+  struct DenseLayer
+    w
+    b
+  end
+
+  Functors.@functor DenseLayer
+
+  loss(m) = sum([sum(abs2, p) for p in trainables(m)])
+
+  model = DenseLayer([1. 2.; 3. 4.], [0., 0.])
+
+  g = gradient(m -> loss(gradient(loss, m)), model)[1]
+  @test g.w == [8.0 16.0; 24.0 32.0]
+  @test g.b == [0.0, 0.0]
+end

--- a/test/trainables.jl
+++ b/test/trainables.jl
@@ -83,7 +83,7 @@ end
   @test g == (a = ((x = [2.0, 4.0, 6.0], y = nothing, z = [8.0, 10.0, 12.0]), nothing), b = ([2.0, 4.0, 6.0], nothing), c = ((x = [2.0, 4.0, 6.0], y = [2.0, 4.0, 6.0], z = [8.0, 10.0, 12.0]), nothing))
   
   g = gradient(loss, m6)[1]
-  @test g = (a = [2.0, 4.0, 6.0], b = ComplexF64[8.0 + 2.0im], c = [2.0, 4.0, 6.0])
+  @test g == (a = [2.0, 4.0, 6.0], b = ComplexF64[8.0 + 2.0im], c = [2.0, 4.0, 6.0])
   
   g = gradient(loss, m7)[1]
   @test g == (a = (nothing, [2.0, 4.0, 6.0]), b = nothing, c = nothing)


### PR DESCRIPTION
An alternative to #57 adding the `trainables` method that returns a vector of arrays. 

I'm playing with different implementations at the moment. The output of the `perf()` function is 
```
trainables1
  1.717 μs (33 allocations: 1.48 KiB)
trainables2
  2.708 μs (63 allocations: 3.12 KiB)
trainables3
  11.208 μs (147 allocations: 4.39 KiB)

gradient trainables2
  1.546 ms (7157 allocations: 304.39 KiB)
gradient trainables3
  249.625 μs (2289 allocations: 115.39 KiB)
```
`trainables1` is the fastest but since it is mutating it needs a custom `rrule` for differentiation. Probably the rrule for `destructor` can be adapted for this case
https://github.com/FluxML/Optimisers.jl/blob/master/src/destructure.jl

The gradients of the other two implementations are very slow, also in these cases we would need a custom rule.

#### TODO
- [x] write custom differentiation rules
- [x] take care of shared parameters (automatically done by `fmap`)
- [x] tests
- [x] docs
