### PR TITLE
Add `trainables_nt`

### DIFF
--- a/src/Optimisers.jl
+++ b/src/Optimisers.jl
@@ -5,6 +5,7 @@ using Functors: functor, fmap, fmap_with_path,
                 isleaf, @functor, fmapstructure, children, AbstractWalk
 using LinearAlgebra
 
+
 include("interface.jl")
 export AbstractRule
 
@@ -16,7 +17,7 @@ include("destructure.jl")
 export destructure
 
 include("trainables.jl")
-export trainables
+export trainables, trainables_nt
 export KeyPath, haskeypath, getkeypath # from Functors.jl
 
 include("rules.jl")

--- a/test/trainables.jl
+++ b/test/trainables.jl
@@ -139,3 +139,22 @@ end
     @test g.y == [2.0, 4.0, 6.0]
     @test g.z === nothing
 end
+
+using Flux, Optimisers
+using ComponentArrays
+using Test
+
+
+model0 = Chain(
+  Dense(784, 32, relu),
+  Dense(32, 10))
+
+ps, re = trainables_nt(model0)
+@test ps.layers._1.weight === model0[1].weight
+model1 = re(ps)
+@test model1[1].weight === ps.layers._1.weight
+
+v = ComponentVector(ps)
+v2 = 2 * v
+model2 = re(v2)
+@test model2[1].weight === v2.layers._1.weight


### PR DESCRIPTION
This is a proposal for an alternative to `destructure` which doesn't completely flatten the parameters but returns a nested named tuple. The associated reconstructor can be be used on `ComponentArray`s as well.