### PR TITLE
restrict AdamW's fields to Float64 

### DIFF
--- a/src/rules.jl
+++ b/src/rules.jl
@@ -530,7 +530,7 @@ Implemented as an [`OptimiserChain`](@ref) of [`Adam`](@ref) and [`WeightDecay`]
 """
 struct AdamW <: AbstractRule
   eta::Float64
-  beta::Float64
+  beta::Tuple{Float64, Float64}
   lambda::Float64
   epsilon::Float64
   couple::Bool

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -528,11 +528,11 @@ Implemented as an [`OptimiserChain`](@ref) of [`Adam`](@ref) and [`WeightDecay`]
     The previous rule, which is closer to the original paper, can be obtained by setting `AdamW(..., couple=false)`.
     See [this issue](https://github.com/FluxML/Flux.jl/issues/2433) for more details.
 """
-struct AdamW{T1,T2,T3,T4} <: AbstractRule
-  eta::T1
-  beta::T2
-  lambda::T4
-  epsilon::T3
+struct AdamW <: AbstractRule
+  eta::Float64
+  beta::Float64
+  lambda::Float64
+  epsilon::Float64
   couple::Bool
 end
 


### PR DESCRIPTION
As per comment https://github.com/FluxML/Optimisers.jl/pull/198#discussion_r1880405919,
since we do it for any other rule (explicitly or through `@def`) except for `Descent`.

Is there any reason why `Descent` is left out @mcabbott ? 
