### PR TITLE
Controlling which optimizer rule you're adjusting.

### DIFF
--- a/src/adjust.jl
+++ b/src/adjust.jl
@@ -144,3 +144,33 @@ function _adjust(r::T, nt::NamedTuple) where T <: AbstractRule
   end
   T(vals...)  # relies on having the default constructor
 end
+
+###
+#adjust with type control
+###
+
+adjust!(ℓ::Leaf, oT::Type, eta::Real) = (ℓ.rule = adjust(ℓ.rule, oT, eta); nothing)
+adjust!(ℓ::Leaf, oT::Type; kw...) = (ℓ.rule = adjust(ℓ.rule, oT; kw...); nothing)
+
+adjust(ℓ::Leaf, oT::Type, eta::Real) = Leaf(adjust(ℓ.rule, oT, eta), ℓ.state, ℓ.frozen)
+adjust(ℓ::Leaf, oT::Type; kw...) = Leaf(adjust(ℓ.rule, oT; kw...), ℓ.state, ℓ.frozen)
+
+adjust!(tree, oT::Type, eta::Real) = foreach(st -> adjust!(st, oT, eta), tree)
+adjust!(tree, oT::Type; kw...) = foreach(st -> adjust!(st, oT; kw...), tree)
+
+adjust(r::AbstractRule, oT::Type, eta::Real) = ifelse(isa(r, oT), adjust(r, eta), r)
+adjust(r::AbstractRule, oT::Type; kw...) = ifelse(isa(r, oT), adjust(r; kw...), r)
+
+adjust!(r::AbstractRule, oT::Type, eta::Real) = ifelse(isa(r, oT), adjust!(r, eta), r)
+adjust!(r::AbstractRule, oT::Type; kw...) = ifelse(isa(r, oT), adjust!(r; kw...), r)
+
+function adjust(tree, oT::Type, eta::Real)
+  t′ = fmap(copy, tree; exclude = maywrite)
+  adjust!(t′, oT, eta)
+  t′
+end
+function adjust(tree, oT::Type; kw...)
+  t′ = fmap(copy, tree; exclude = maywrite)
+  adjust!(t′, oT; kw...)
+  t′
+end

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -799,6 +799,9 @@ end
 adjust(ℓ::OptimiserChain, eta::Real) = OptimiserChain(map(opt -> adjust(opt, eta), ℓ.opts)...)
 adjust(ℓ::OptimiserChain; kw...) = OptimiserChain(map(opt -> adjust(opt; kw...), ℓ.opts)...)
 
+adjust(ℓ::OptimiserChain, oT::Type, eta::Real) = OptimiserChain(map(opt -> adjust(opt, oT, eta), ℓ.opts)...)
+adjust(ℓ::OptimiserChain, oT::Type; kw...) = OptimiserChain(map(opt -> adjust(opt, oT; kw...), ℓ.opts)...)
+
 
 """
     AccumGrad(n::Int)


### PR DESCRIPTION
This PR tries to address the issue in https://github.com/FluxML/Optimisers.jl/issues/201 where, if two Rules have the same parameter name, you can't use the `adjust` interface to control them independently.

This is intended to be non-breaking, so the previous behavior is undisturbed:
<img width="1107" alt="image" src="https://github.com/user-attachments/assets/8346c642-f373-46ff-a20a-8cd58c14a12b" />
but you can now additionally specify the type you wish to change:
<img width="1099" alt="image" src="https://github.com/user-attachments/assets/a30f5af1-f57c-4d37-bd62-603be4c40027" />

Implementation-wise, this added quite a few `adjust` and `adjust!` methods. I'm not 100% sure all of them are needed, so maybe we can prune a few back but I wasn't quite sure of the edge cases I'm not aware of, so I tried to cover everything.

I this PR's version, analogous to above, if you just pass in a float you'll change eta, but only in the optimizer you intend:
<img width="1099" alt="image" src="https://github.com/user-attachments/assets/0d780ad7-df80-41b7-bba2-dd84453d7834" />
This is maybe less critical to have, so we could cut back all of the non-keyword methods that specify a type.

Doing all this introduces a bit of core package developer complexity, but it is all generic so you shouldn't need to touch it when adding a new optimizer, and the usage seems pretty intuitive from a user perspective, so I don't think it adds interface complexity. To be honest, the current behavior seems like a footgun, and as a user with an OptimizerChain, I'd only ever use `adjust`/`adjust!` while specifying the type, because otherwise I'd have to check the parameter list of all the OptimizerChain components just to be sure I'm not doing something I don't intend.

### PR Checklist

- [ ] Tests are added
- [ ] Documentation, if applicable
