### PR TITLE
Reactant: add extension to prevent stackoverflow

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,10 +13,12 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 [weakdeps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 EnzymeCore = "f151be2c-9106-41f4-ab19-57ee4f262869"
+Reactant = "3c362404-f566-11ee-1572-e11a4b42c853"
 
 [extensions]
 OptimisersAdaptExt = ["Adapt"]
 OptimisersEnzymeCoreExt = "EnzymeCore"
+OptimisersReactantExt = "Reactant"
 
 [compat]
 Adapt = "4"

--- a/ext/OptimisersReactantExt.jl
+++ b/ext/OptimisersReactantExt.jl
@@ -1,0 +1,8 @@
+module OptimisersReactantExt
+
+import Optimisers
+import Reactant
+
+Optimisers._eps(T::Type{<:Reactant.TracedRNumber{<:AbstractFloat}}, e) = T(e)
+
+end


### PR DESCRIPTION
Add extension to prevent stackoverflow when using Reactant.

Origin of bug in https://github.com/FluxML/Fluxperimental.jl/pull/28

```
simple train!: Error During Test at /Users/wmoses/git/Fluxperimental.jl/test/reactant.jl:152
  Got exception outside of a @test
  StackOverflowError:
  Stacktrace:
    [1] mlirOperationCreate
      @ ~/git/Reactant.jl/src/mlir/libMLIR_h.jl:1005 [inlined]
    [2] create_operation(name::String, loc::Reactant.MLIR.IR.Location; results::Vector{Reactant.MLIR.IR.Type}, operands::Vector{Reactant.MLIR.IR.Value}, owned_regions::Vector{Reactant.MLIR.IR.Region}, successors::Vector{Reactant.MLIR.IR.Block}, attributes::Vector{Reactant.MLIR.IR.NamedAttribute}, result_inference::Bool)
      @ Reactant.MLIR.IR ~/git/Reactant.jl/src/mlir/IR/Operation.jl:319
    [3] constant(; output::Reactant.MLIR.IR.Type, value::Reactant.MLIR.IR.Attribute, location::Reactant.MLIR.IR.Location)
      @ Reactant.MLIR.Dialects.stablehlo ~/git/Reactant.jl/src/mlir/Dialects/StableHLO.jl:1134
    [4] constant
      @ ~/git/Reactant.jl/src/mlir/Dialects/StableHLO.jl:1126 [inlined]
    [5] constant(x::Array{Float32, 0}; location::Reactant.MLIR.IR.Location)
      @ Reactant.Ops ~/git/Reactant.jl/src/Ops.jl:74
    [6] constant(x::Array{Float32, 0})
      @ Reactant.Ops ~/git/Reactant.jl/src/Ops.jl:69
    [7] promote_to(::Type{Reactant.TracedRNumber{Float32}}, rhs::Int64)
      @ Reactant.TracedRNumberOverrides ~/git/Reactant.jl/src/TracedRNumber.jl:70
    [8] TracedRNumber
      @ ~/git/Reactant.jl/src/TracedRNumber.jl:56 [inlined]
    [9] convert
      @ ./number.jl:7 [inlined]
   [10] zero
      @ ./number.jl:309 [inlined]
   [11] float
      @ ./float.jl:311 [inlined]
   [12] _eps(T::Type{Reactant.TracedRNumber{Float32}}, e::Float64) (repeats 79970 times)
      @ Optimisers ~/.julia/packages/Optimisers/a4OnF/src/utils.jl:20
Test Summary:                           | Pass  Error  Broken  Total     Time
```
