### PR TITLE
Add  methods `adjust(state, rule)` and `adjust!(state, rule)`.

### DIFF
--- a/src/adjust.jl
+++ b/src/adjust.jl
@@ -101,15 +101,31 @@ julia> Optimisers.adjust(st2; beta = (0.777, 0.909), delta = 11.1)  # delta acts
 julia> Optimisers.adjust(st; beta = "no such field")  # silently ignored!
 (vec = Leaf(Nesterov(0.123, 0.9), Float32[-0.016, -0.088]), fun = ())
 ```
+
+The argument `η` may also be a new optimisation rule, of the same type as the rule
+currently embedded in the state tree, as in the next example:
+
+```
+julia> st = Optimisers.setup(Nesterov(0.123, 0.9), m)
+(vec = Leaf(Nesterov(eta=0.123, rho=0.9), Float32[0.0, 0.0]), fun = ())
+
+julia> Optimisers.adjust!(st, Nesterov(0.456, 0.8))
+
+julia> st
+(vec = Leaf(Nesterov(eta=0.456, rho=0.8), Float32[0.0, 0.0]), fun = ())
+```
 """
 adjust!(tree, eta::Real) = foreach(st -> adjust!(st, eta), tree)
 adjust!(tree; kw...) = foreach(st -> adjust!(st; kw...), tree)
+adjust!(tree, r::AbstractRule) = foreach(st -> adjust!(st, r), tree)
 
 adjust!(ℓ::Leaf, eta::Real) = (ℓ.rule = adjust(ℓ.rule, eta); nothing)
 adjust!(ℓ::Leaf; kw...) = (ℓ.rule = adjust(ℓ.rule; kw...); nothing)
+adjust!(ℓ::Leaf{R}, r::R) where R <: AbstractRule = (ℓ.rule = r; nothing)
 
 adjust(ℓ::Leaf, eta::Real) = Leaf(adjust(ℓ.rule, eta), ℓ.state, ℓ.frozen)
 adjust(ℓ::Leaf; kw...) = Leaf(adjust(ℓ.rule; kw...), ℓ.state, ℓ.frozen)
+adjust(ℓ::Leaf{R}, r::R) where R <: AbstractRule = Leaf(r, ℓ.state, ℓ.frozen)
 
 """
     adjust(tree, η) -> tree
@@ -126,6 +142,12 @@ function adjust(tree; kw...)
   adjust!(t′; kw...)
   t′
 end
+function adjust(tree, r::AbstractRule)
+  t′ = fmap(copy, tree; exclude = maywrite)
+  adjust!(t′, r)
+  t′
+end
+
 
 """
     Optimisers.adjust(rule::RuleType, η::Real) -> rule

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -61,10 +61,10 @@ end
       g4 = Tangent{typeof(m)}(g...)
       s4, m4 = Optimisers.update!(s, ([1.0, 2.0],), g4)
       @test m4[1] ≈ [1,2] .- 0.1 .* [25, 33]
-      
+
       o5 = Momentum(0.1)
       s5 = Optimisers.setup(o5, m)
-      
+
       s6, m6 = Optimisers.update(s5, m, g)
       @test s6[1].state ≈ [2.5, 3.3]
       @test s5[1].state == [0, 0]  # not mutated -- wrong on v0.2.9
@@ -331,6 +331,43 @@ end
       @test mp1.γ.rule.rule.rho == 0.7
     end
 
+    @testset "adjust/adjust! with completely new rule replacement" begin
+          model =  Foo([1.0, 2.0], (a = sin, b = [3.0, 4.0], c = 5))
+          rule = OptimiserChain(
+              WeightDecay(0.1),
+              SignDecay(0.2),
+              OptimiserChain(
+                  ClipGrad(),
+                  Adam(),
+              ),
+          )
+          rule2 = OptimiserChain(
+              WeightDecay(0.15),
+              SignDecay(0.25),
+              OptimiserChain(
+                  ClipGrad(),
+                  Adam(),
+              ),
+          )
+          state = Optimisers.setup(rule, model)
+          state2 = Optimisers.setup(rule2, model)
+          @assert state != state2
+
+          # adjust `state` to match `rule2`, not `rule`:
+          Optimisers.adjust!(state, rule2)
+
+          # `state` and `state2` should now be the same:
+          @test state == state2
+
+          # reset `state`, so it's different again:
+          state = Optimisers.setup(rule, model)
+          @assert state != state2
+
+          # test non-mutating form, `adjust`:
+          state = Optimisers.adjust(state, rule2)
+          @test state == state2
+    end
+
     @testset "freeze/thaw" begin
       m = (x=[1.0, 2.0], y=([3.0, 4.0], sin));
       st = Optimisers.setup(Descent(0.1), m);
@@ -458,10 +495,10 @@ end
          @test auto.a !== auto.b  # not tied just by value
 
          trick = (a = auto.a, b = auto.a, c = auto.c, d= auto.d)  # makes a & b tied
-  
+
          trick2, model2 = Optimisers.update(trick, model, (a=[3,3], b=[7,7], c=[3,3], d=[10, 10]))
          trick3, model3 = Optimisers.update(trick2, model2, (a=[3,3], b=[7,7], c=[3,3], d=[10, 10]))
-         
+
          @test model3.a ≈ model3.b ≈ model3.d  # same as having the gradients added
          @test !(model3.a ≈ model3.c)
          @test trick3.a === trick3.b  # leaves remain shared

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -341,6 +341,8 @@ end
                   Adam(),
               ),
           )
+
+          # a new rule of the same type:
           rule2 = OptimiserChain(
               WeightDecay(0.15),
               SignDecay(0.25),
@@ -349,11 +351,25 @@ end
                   Adam(),
               ),
           )
+
+          # a new rule of incompatible type:
+          bad_rule = OptimiserChain(
+              WeightDecay(0.1),
+              SignDecay(0.2),
+              OptimiserChain(
+                  ClipGrad(),
+                  Descent(),
+              ),
+          )
+
           state = Optimisers.setup(rule, model)
           state2 = Optimisers.setup(rule2, model)
           @assert state != state2
 
-          # adjust `state` to match `rule2`, not `rule`:
+          # attempting to replace with a incompatible rule throws an error:
+          @test_throws MethodError Optimisers.adjust!(state, bad_rule)
+
+          # adjust `state` to match `rule2`, instead of  `rule`:
           Optimisers.adjust!(state, rule2)
 
           # `state` and `state2` should now be the same:


### PR DESCRIPTION
At present we have `adjust!(state, eta::Real)` to update a  learning rate, and there is a version with kwargs to update other (nested) parameters. This PR adds `adjust!(state, rule::AbstractRule)` and a non-mutating version, `adjust(state, rule::AbstractRule)` to allow updating the entire embedded rule, to resolve #223.


### PR Checklist

- [x] Tests are added
- [x] Documentation, if applicable
