### PR TITLE
OptimisersReactantExt: add support for RAdam

### DIFF
--- a/ext/OptimisersReactantExt.jl
+++ b/ext/OptimisersReactantExt.jl
@@ -1,7 +1,7 @@
 module OptimisersReactantExt
 
-using Optimisers: Optimisers
-using Reactant: TracedRNumber, @trace
+using Optimisers: Optimisers, @..
+using Reactant: Reactant, TracedRNumber, TracedRArray, @trace
 
 # Once https://github.com/EnzymeAD/Reactant.jl/pull/835 we can support throwing errors
 # from compiled MLIR
@@ -26,6 +26,53 @@ function Optimisers.apply!(
         counter += 1
     end
     return (accum_dx, counter), dx_final
+end
+
+# RAdam under tracing. Stock `apply!` (rules.jl) takes a host-side
+# `if ρ > 4` branch, which fires `TypeError: non-boolean
+# (TracedRNumber{Bool}) used in boolean context` because `ρ` is a
+# TracedRNumber whenever the state's `βt` tuple or its `mt`/`vt`
+# arrays trace, regardless of whether the rule's own `beta` field was
+# promoted. This variant uses `ifelse` / `ifelse.` so both arms lower
+# to XLA selects with no host branching. The `one(ρ)` fallback inside
+# `sqrt` ensures the argument is valid when ρ ≤ 4 (the value is
+# discarded by the outer broadcasted `ifelse.`). Dispatch fires
+# whenever `x` is a `TracedRArray`, which is the only situation in
+# which `apply!` runs inside a Reactant trace, so eager / CPU users
+# continue to hit the stock method.
+# `T(::TracedRNumber{T})` is not defined, so the stock `T(o.eta)` /
+# `T.(o.beta)` lines blow up when the rule's scalars were already
+# promoted via `to_rarray(opt; track_numbers=...)`. Treat already-traced
+# scalars as no-ops and only convert host numbers.
+@inline _radam_to(::Type{T}, x::TracedRNumber) where {T} = x
+@inline _radam_to(::Type{T}, x) where {T} = T(x)
+@inline _radam_eps(::Type{T}, x::TracedRNumber) where {T} = x
+@inline _radam_eps(::Type{T}, x) where {T} = Optimisers._eps(T, x)
+
+function Optimisers.apply!(
+    o::Optimisers.RAdam, state, x::TracedRArray{T}, dx,
+) where {T}
+    η = _radam_to(T, o.eta)
+    β = map(b -> _radam_to(T, b), o.beta)
+    ϵ = _radam_eps(T, o.epsilon)
+    ρ∞ = real(2 / (1 - β[2]) - 1)
+
+    mt, vt, βt, t = state
+
+    @.. mt = β[1] * mt + (1 - β[1]) * dx
+    @.. vt = β[2] * vt + (1 - β[2]) * abs2(dx)
+    ρ = real(ρ∞ - 2 * t * βt[2] / (1 - βt[2]))
+
+    r = sqrt(ifelse(ρ > 4,
+        (ρ - 4) * (ρ - 2) * ρ∞ / ((ρ∞ - 4) * (ρ∞ - 2) * ρ),
+        one(ρ)))
+
+    mt_bc = mt ./ (1 .- βt[1])
+    dx′ = ifelse.(ρ > 4,
+        mt_bc ./ (sqrt.(vt ./ (1 .- βt[2])) .+ ϵ) .* η .* r,
+        mt_bc .* η)
+
+    return (mt, vt, βt .* β, t + 1), dx′
 end
 
 end

--- a/test/reactant.jl
+++ b/test/reactant.jl
@@ -3,7 +3,7 @@ Pkg.add("Reactant")
 
 using Reactant, Optimisers
 
-@testset for opt in (Descent(0.011), Momentum(0.011), Adam(0.011), AdamW(0.011))
+@testset for opt in (Descent(0.011), Momentum(0.011), Adam(0.011), AdamW(0.011), RAdam(0.011))
     opt_ra = Reactant.to_rarray(opt; track_numbers=AbstractFloat)
 
     x_ra = Reactant.to_rarray((rand(3), rand(2)))
@@ -35,6 +35,48 @@ using Reactant, Optimisers
 
         st_opt2_ra, x_ra2 = @jit Optimisers.update!(st_opt_ra, x_ra, gs_ra)
     end
+end
+
+@testset "RAdam parity with CPU" begin
+    # Branch coverage: the rectification threshold `ρ > 4` is a
+    # deterministic function of `β₂` and the step counter `t` (it does
+    # not see the gradients at all — see Liu et al. 2019), and for any
+    # reasonable `β₂` the warmup arm fires at t = 1..4 and the
+    # rectified arm at t ≥ 5. Running 8 steps therefore exercises both
+    # arms regardless of how `grads` are sampled. With the default
+    # `β₂ = 0.999` used below: ρ ≈ {1.0, 2.0, 3.0, 4.0} at t = 1..4,
+    # then ≈ {5.0, 6.0, 7.0, 8.0} at t = 5..8.
+    rng = Random.MersenneTwister(0)
+    p_cpu = randn(rng, Float32, 6)
+    grads = [randn(rng, Float32, 6) for _ in 1:8]
+
+    opt_cpu = RAdam(0.01f0, (0.9f0, 0.999f0))
+    st_cpu = Optimisers.setup(opt_cpu, p_cpu)
+    p_iter = copy(p_cpu)
+    for g in grads
+        st_cpu, p_iter = Optimisers.update(st_cpu, p_iter, g)
+    end
+    p_cpu_final = p_iter
+
+    opt_ra = Reactant.to_rarray(opt_cpu; track_numbers=AbstractFloat)
+    p_ra = Reactant.to_rarray(copy(p_cpu))
+    st_ra = @jit Optimisers.setup(opt_ra, p_ra)
+
+    p_outofplace = p_ra
+    st_outofplace = st_ra
+    for g in grads
+        g_ra = Reactant.to_rarray(g)
+        st_outofplace, p_outofplace = @jit Optimisers.update(st_outofplace, p_outofplace, g_ra)
+    end
+    @test Array(p_outofplace) ≈ p_cpu_final rtol=1e-5 atol=1e-6
+
+    p_inplace = Reactant.to_rarray(copy(p_cpu))
+    st_inplace = @jit Optimisers.setup(opt_ra, p_inplace)
+    for g in grads
+        g_ra = Reactant.to_rarray(g)
+        st_inplace, p_inplace = @jit Optimisers.update!(st_inplace, p_inplace, g_ra)
+    end
+    @test Array(p_inplace) ≈ p_cpu_final rtol=1e-5 atol=1e-6
 end
 
 @testset "AccumGrad" begin


### PR DESCRIPTION
This adds support for RAdam in Reactant.jl `@jit` / `@compile` by making the conditional use `ifelse`. This specialization should only be dispatched to when the input is traced.

Not sure documentation is needed here. From a user perspective RAdam should just work like any other optimiser when using Reactant.

### PR Checklist

- [x] Tests are added
- [x] Documentation, if applicable
