### PR TITLE
Make the Reactant optimiser wrapper trace-safe under `@jit setup`

### DIFF
--- a/ext/OptimisersReactantMLDataDevicesExt.jl
+++ b/ext/OptimisersReactantMLDataDevicesExt.jl
@@ -2,12 +2,18 @@ module OptimisersReactantMLDataDevicesExt
 
 using Optimisers: Optimisers
 using Reactant: Reactant
-using MLDataDevices: ReactantDevice, get_device, with_track_numbers
+using MLDataDevices: ReactantDevice, get_device, with_track_numbers, reactant_device
 
 # --- device-preserving eltype conversion ---------------------------------
 # On-device numbers must be rebuilt through their concrete constructor so they
 # stay tracked; `convert(T, x)` / `T(x)` would pull them back to the host as
 # compile-time constants. (Reproduces Lux's `Utils.convert_eltype`.)
+# The eager path hits the `Concrete*` methods (keeping the scalar on-device). Under
+# `@jit setup` the scalars are `TracedRNumber`s AND `T === eltype(x) === TracedRNumber{…}`,
+# so the `x::Number` method runs `convert(TracedRNumber{…}, x::TracedRNumber)`, which
+# routes through the `TracedRNumber{…}` constructor and stays traced. (Do NOT add a
+# `TracedRNumber` method here: with `T` already a `TracedRNumber` type it would try to
+# build the invalid `TracedRNumber{TracedRNumber{…}}`.)
 _convert_eltype(::Type{T}, x::Number) where {T<:Number} = convert(T, x)
 _convert_eltype(::Type{T}, x::Reactant.ConcretePJRTNumber) where {T<:Number} =
     Reactant.ConcretePJRTNumber{T}(x)
@@ -45,10 +51,18 @@ end
 function Optimisers.init(
     opt::ReactantOptimiser{<:Optimisers.RAdam}, x::AbstractArray{T}
 ) where {T}
-    # NOTE: `get_device` errors inside a Reactant trace, so a `ReactantOptimiser{RAdam}`
-    # must have `setup` run eagerly (host-side), not under `@jit`.
-    dev = with_track_numbers(get_device(opt), Integer)
-    return zero(x), zero(x), _convert_eltype.((T,), opt.opt.beta), dev(1)
+    betas = _convert_eltype.((T,), opt.opt.beta)
+    # The step counter must stay tracked so it flows through a compiled `update!` as a
+    # runtime variable (rather than being frozen as a constant, forcing a recompile per
+    # step). Derive a tracked `1` from an already-tracked scalar (the promoted `beta`)
+    # instead of `with_track_numbers(get_device(opt), Integer)(1)`: `get_device` errors
+    # inside a trace, and it was the only thing stopping `@jit Optimisers.setup(opt, ps)`
+    # working for RAdam. `+ 1` (not `+ one(T)`: under a trace `T === TracedRNumber{…}`)
+    # promotes correctly for both concrete and traced scalars. A tracked `Float` counter
+    # is numerically identical to the stock integer one — RAdam's `apply!` only uses `t`
+    # in float arithmetic (`2t·βt`) and as `t + 1`.
+    t = betas[1] - betas[1] + 1
+    return zero(x), zero(x), betas, t
 end
 
 function Optimisers.init(
@@ -76,8 +90,19 @@ function Optimisers._adjust(
 end
 
 # --- construction helpers -------------------------------------------------
+# Device-less form: default to the current Reactant device. Dispatches to the
+# device-aware methods below, so `OptimiserChain` / `AccumGrad` / `ClipNorm` (all
+# `<: AbstractRule`) and the idempotency guard are all reached correctly.
+Optimisers.make_reactant_compatible(opt::Optimisers.AbstractRule) =
+    Optimisers.make_reactant_compatible(opt, reactant_device())
+
 Optimisers.make_reactant_compatible(opt::Optimisers.AbstractRule, dev::ReactantDevice) =
     ReactantOptimiser(with_track_numbers(dev, AbstractFloat)(opt))
+
+# Idempotent: re-wrapping an already-wrapped rule is a no-op. Guards against double
+# wrapping (a rule passed through `make_reactant_compatible` twice, or an
+# `OptimiserChain` that already holds wrapped rules).
+Optimisers.make_reactant_compatible(opt::ReactantOptimiser, ::ReactantDevice) = opt
 
 Optimisers.make_reactant_compatible(opt::Optimisers.OptimiserChain, dev::ReactantDevice) =
     ReactantOptimiser(Optimisers.OptimiserChain(

--- a/src/Optimisers.jl
+++ b/src/Optimisers.jl
@@ -28,14 +28,20 @@ export Descent, Adam, Momentum, Nesterov, Rprop, RMSProp,
        AccumGrad, MixedPrecision
 
 """
-    Optimisers.make_reactant_compatible(rule::AbstractRule, dev) -> rule
+    Optimisers.make_reactant_compatible(rule::AbstractRule, [dev]) -> rule
 
 Wrap `rule` so its scalar hyper-parameters (learning rate, momenta, step counters)
 are stored as tracked numbers on the Reactant device `dev`, instead of being baked
 into the compiled program as constants — letting e.g. the learning rate be changed
 with [`adjust!`](@ref) without recompilation. `dev` must be a
-`MLDataDevices.ReactantDevice`; methods are provided by the extension loaded when
-both Reactant.jl and MLDataDevices.jl are present.
+`MLDataDevices.ReactantDevice`; it defaults to `MLDataDevices.reactant_device()`.
+
+The wrapped rule is safe to `setup` either eagerly or under `@jit`, e.g.
+`@jit Optimisers.setup(rule, ps)`. It is also idempotent: wrapping an
+already-wrapped rule returns it unchanged.
+
+Methods are provided by the extension loaded when both Reactant.jl and
+MLDataDevices.jl are present.
 """
 function make_reactant_compatible end
 

--- a/test/reactant_mldatadevices.jl
+++ b/test/reactant_mldatadevices.jl
@@ -62,3 +62,43 @@ end
     st2 = Optimisers.adjust(st; eta = 0.005f0)
     @test st2[1].rule.opt.eta ≈ 0.005f0
 end
+
+# Lux's actual flow: wrap EAGERLY, then run `setup` UNDER `@jit`. This worked for
+# every rule except RAdam, whose init called `get_device` (errors in a trace); the
+# tracked counter is now derived from an already-tracked scalar instead.
+@testset "setup runs under @jit: $(typeof(opt).name.name)" for opt in (
+        Adam(0.01f0),
+        RAdam(0.01f0),
+    )
+    ps = cdev((randn(Float32, 4), randn(Float32, 2)))
+    opt_ra = Optimisers.make_reactant_compatible(opt, get_device(ps))
+    st = @jit Optimisers.setup(opt_ra, ps)
+
+    gs = cdev((randn(Float32, 4), randn(Float32, 2)))
+    st2, ps2 = @jit Optimisers.update!(st, ps, gs)
+    @test all(isfinite, Array(ps2[1]))
+
+    # A second step advances the tracked RAdam counter as a runtime variable.
+    gs2 = cdev((randn(Float32, 4), randn(Float32, 2)))
+    st3, ps3 = @jit Optimisers.update!(st2, ps2, gs2)
+    @test all(isfinite, Array(ps3[1]))
+end
+
+@testset "make_reactant_compatible is idempotent" begin
+    ps = cdev((randn(Float32, 3),))
+    dev = get_device(ps)
+    opt1 = Optimisers.make_reactant_compatible(Adam(0.01f0), dev)
+    @test Optimisers.make_reactant_compatible(opt1, dev) === opt1   # two-arg form
+    @test Optimisers.make_reactant_compatible(opt1) === opt1        # device-less form
+end
+
+@testset "device-less make_reactant_compatible uses the default device" begin
+    opt = Optimisers.make_reactant_compatible(Adam(0.01f0))
+    @test get_device(opt) isa ReactantDevice
+
+    ps = cdev((randn(Float32, 3),))
+    st = Optimisers.setup(opt, ps)
+    gs = cdev((randn(Float32, 3),))
+    st2, ps2 = @jit Optimisers.update!(st, ps, gs)
+    @test all(isfinite, Array(ps2[1]))
+end


### PR DESCRIPTION
Follow-up to #227.

`@jit Optimisers.setup(opt, ps)` — the flow Lux uses — already worked for every wrapped rule except `RAdam`, whose `init` called `get_device(opt)`, which errors inside a Reactant trace. This derives `RAdam`'s tracked step counter from an already-tracked scalar instead, so its `setup` traces like the other rules. (Under a trace `eltype(x) === TracedRNumber{…}`, so the beta conversion already stayed traced through the existing `convert` fallback.)

Also small API polish on `make_reactant_compatible`:
- idempotent — re-wrapping a `ReactantOptimiser` is a no-op
- device-less form `make_reactant_compatible(rule)` defaulting to `reactant_device()`

`setup` is unchanged, and there is no change to Lux's behaviour.

Verified locally on Julia 1.12.6: `test/reactant_mldatadevices.jl` passes 24/24 — the new `@jit setup` (Adam + RAdam), idempotency, and device-less sets, alongside the existing eager / learning-rate-tracked / `adjust!` sets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
