### PR TITLE
Implement Muon Optimizer

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -21,6 +21,7 @@ Optimisers.NAdam
 Optimisers.AdamW
 Optimisers.AdaBelief
 Optimisers.Lion
+Optimisers.Muon
 ```
 
 In addition to the main course, you may wish to order some of these condiments:

--- a/src/Optimisers.jl
+++ b/src/Optimisers.jl
@@ -25,7 +25,8 @@ include("rules.jl")
 export Descent, Adam, Momentum, Nesterov, Rprop, RMSProp,
        AdaGrad, AdaMax, AdaDelta, AMSGrad, NAdam, AdamW, RAdam, OAdam, AdaBelief,
        WeightDecay, SignDecay, ClipGrad, ClipNorm, OptimiserChain, Lion,
-       AccumGrad, MixedPrecision
+    AccumGrad, MixedPrecision,
+    Muon
 
 """
     Optimisers.make_reactant_compatible(rule::AbstractRule, [dev]) -> rule

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -21,7 +21,7 @@ struct Descent{T} <: AbstractRule
   eta::T
 end
 
-Descent(; eta=1f-1) = Descent(eta)
+Descent(; eta = 1f-1) = Descent(eta)
 
 init(o::Descent, x::AbstractArray) = nothing
 
@@ -121,11 +121,11 @@ struct RMSProp{Teta,Trho,Teps} <: AbstractRule
   centred::Bool
 end
 
-function RMSProp(η, ρ=0.9, ϵ=1e-8; centred::Bool=false, centered::Bool=false)
+function RMSProp(η, ρ = 0.9, ϵ = 1e-8; centred::Bool = false, centered::Bool = false)
   η < 0 && throw(DomainError(η, "the learning rate cannot be negative"))
   return RMSProp(float(η), float(ρ), float(ϵ), centred | centered)
 end
-RMSProp(; eta=0.001, rho=0.9, epsilon=1e-8, kw...) = RMSProp(eta, rho, epsilon; kw...)
+RMSProp(; eta = 0.001, rho = 0.9, epsilon = 1e-8, kw...) = RMSProp(eta, rho, epsilon; kw...)
 
 init(o::RMSProp, x::AbstractArray) = (zero(x), o.centred ? zero(x) : false)
 
@@ -169,26 +169,26 @@ learning algorithm that depends only on the sign of the gradient.
 - Step sizes (`Γ::Tuple == gamma`): Mminimal and maximal allowed step sizes.
 """
 @def struct Rprop <: AbstractRule
-  eta = 1e-3
-  ell = (0.5, 1.2)
-  gamma = (1e-6, 50.0)
+    eta =  1e-3
+    ell = (0.5, 1.2)
+    gamma = (1e-6, 50.0)
 end
 
 init(o::Rprop, x::AbstractArray) = (zero(x), onevalue(o.eta, x))
 
 function apply!(o::Rprop, state, x::AbstractArray{T}, dx) where T
-  ℓ, Γ = T.(o.ell), T.(o.gamma)
-  g, η = state
+    ℓ, Γ = T.(o.ell), T.(o.gamma)
+    g, η = state
+  
+    η = broadcast(g, η, dx) do g, η, dx
+        g * dx > 0 ? min(η * ℓ[2], Γ[2]) : g * dx < 0 ? max(η * ℓ[1], Γ[1]) : η
+    end
+    g = broadcast(g, dx) do g, dx
+        g * dx < 0 ? zero(T) : T(dx)
+    end
+    dx′ = @lazy η * sign(g)
 
-  η = broadcast(g, η, dx) do g, η, dx
-    g * dx > 0 ? min(η * ℓ[2], Γ[2]) : g * dx < 0 ? max(η * ℓ[1], Γ[1]) : η
-  end
-  g = broadcast(g, dx) do g, dx
-    g * dx < 0 ? zero(T) : T(dx)
-  end
-  dx′ = @lazy η * sign(g)
-
-  return (g, η), dx′
+    return (g, η), dx′
 end
 
 """
@@ -284,7 +284,7 @@ function apply!(o::RAdam, state, x::AbstractArray{T}, dx) where T
 
   @.. mt = β[1] * mt + (1 - β[1]) * dx
   @.. vt = β[2] * vt + (1 - β[2]) * abs2(dx)
-  ρ = ρ∞ - 2 * t * βt[2] / (1 - βt[2]) |> real
+  ρ = ρ∞ - 2*t * βt[2] / (1 - βt[2]) |> real
   if ρ > 4
     r = sqrt((ρ - 4) * (ρ - 2) * ρ∞/((ρ∞ - 4) * (ρ∞ - 2) * ρ))
     dx′ = @lazy mt / (1 - βt[1]) / (sqrt(vt / (1 - βt[2])) + ϵ) * η * r
@@ -493,7 +493,7 @@ function apply!(o::NAdam, state, x::AbstractArray{T}, dx) where T
   @.. mt = β[1] * mt + (1 - β[1]) * dx
   @.. vt = β[2] * vt + (1 - β[2]) * abs2(dx)
   dx′ = @lazy (β[1] * mt / (1 - β[1] * βt[1]) + (1 - β[1]) * dx / (1 - βt[1])) /
-              (sqrt(vt * β[2] / (1 - βt[2])) + ϵ) * η
+          (sqrt(vt * β[2] / (1 - βt[2])) + ϵ) * η
 
   return (mt, vt, βt .* β), dx′
 end
@@ -534,12 +534,12 @@ struct AdamW{Teta,Tbeta<:Tuple,Tlambda,Teps} <: AbstractRule
   couple::Bool
 end
 
-function AdamW(η, β=(0.9, 0.999), λ=0.0, ϵ=1e-8; couple::Bool=true)
+function AdamW(η, β = (0.9, 0.999), λ = 0.0, ϵ = 1e-8; couple::Bool = true)
   η < 0 && throw(DomainError(η, "the learning rate cannot be negative"))
   return AdamW(float(η), β, float(λ), float(ϵ), couple)
 end
 
-AdamW(; eta=0.001, beta=(0.9, 0.999), lambda=0.0, epsilon=1e-8, kw...) =
+AdamW(; eta = 0.001, beta = (0.9, 0.999), lambda= 0.0,  epsilon = 1e-8, kw...) =
   AdamW(eta, beta, lambda, epsilon; kw...)
 
 init(o::AdamW, x::AbstractArray{T}) where T = (zero(x), zero(x), T.(o.beta))
@@ -602,7 +602,6 @@ function apply!(o::AdaBelief, state, x::AbstractArray{T}, dx) where T
   return (mt, st, βt .* β), dx′
 end
 
-
 """
     WeightDecay(λ = 5e-4)
     WeightDecay(; [lambda])
@@ -631,15 +630,15 @@ function apply!(o::WeightDecay, state, x::AbstractArray{T}, dx) where T
   return state, dx′
 end
 
-function adjust(r::WeightDecay; gamma=nothing, kw...)
-  if isnothing(gamma)
-    return _adjust(r, NamedTuple(kw))
-  else
-    Base.depwarn("The strength of WeightDecay is now field :lambda, not :gamma", :adjust, force=true)
-    nt = (; lambda=gamma, NamedTuple(kw)...)
-    return _adjust(r, nt)
-  end
-end
+function adjust(r::WeightDecay; gamma = nothing, kw...)
+   if isnothing(gamma)
+     return _adjust(r, NamedTuple(kw))
+   else
+     Base.depwarn("The strength of WeightDecay is now field :lambda, not :gamma", :adjust, force=true)
+     nt = (; lambda = gamma, NamedTuple(kw)...)
+     return _adjust(r, nt)
+   end
+ end
 
 """
     SignDecay(λ = 1e-3)
@@ -713,7 +712,7 @@ struct ClipNorm{To,Tp} <: AbstractRule
   p::Tp
   throw::Bool
 end
-ClipNorm(ω=10, p=2; throw::Bool=true) = ClipNorm(float(ω), float(p), throw)
+ClipNorm(ω = 10, p = 2; throw::Bool = true) = ClipNorm(float(ω), float(p), throw)
 
 init(o::ClipNorm, x::AbstractArray) = nothing
 
@@ -788,10 +787,10 @@ end
 init(o::OptimiserChain, x::AbstractArray) = map(opt -> init(opt, x), o.opts)
 
 function apply!(o::OptimiserChain, states, x, dx, dxs...)
-  foldl(tuple.(o.opts, states); init=((), dx)) do (states′, dx′), (opt, state)
+  foldl(tuple.(o.opts, states); init = ((), dx)) do (states′, dx′), (opt, state)
     if dx′ isa Zero
       return (states′..., state), dx′
-    else
+    else 
       state′, dx′ = apply!(opt, state, x, dx′, dxs...)
       return (states′..., state′), dx′
     end
@@ -897,14 +896,14 @@ g = rand(Float16, 2) # A gradient in low precision
 Optimisers.update!(opt_state, x, g)  
 ```
 """
-struct MixedPrecision{T<:Number,O<:AbstractRule} <: AbstractRule
+struct MixedPrecision{T<:Number, O<:AbstractRule} <: AbstractRule
   rule::O
 end
 
 @functor MixedPrecision
 
-MixedPrecision(rule::AbstractRule) = MixedPrecision{Float32,typeof(rule)}(rule)
-MixedPrecision(T::Type, rule::AbstractRule) = MixedPrecision{T,typeof(rule)}(rule)
+MixedPrecision(rule::AbstractRule) = MixedPrecision{Float32, typeof(rule)}(rule)
+MixedPrecision(T::Type, rule::AbstractRule) = MixedPrecision{T, typeof(rule)}(rule)
 
 function init(o::MixedPrecision{T}, x::AbstractArray) where T
   xT = T.(x)

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -974,9 +974,8 @@ function apply!(o::Muon, state, x::AbstractArray{T,2}, dx) where T
 end
 
 _muon_needs_matrix(x) = throw(ArgumentError(
-  "Muon can only optimise 2-dimensional parameters, but got one with ndims = $(ndims(x)). " *
-  "Scalar and vector parameters, and the input and output layers, should be optimised " *
-  "by another rule such as AdamW."))
+  "Muon can only optimise 2-dimensional parameters, but got one with ndims = $(ndims(x))."
+))
 
 init(o::Muon, x::AbstractArray) = _muon_needs_matrix(x)
 

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -933,7 +933,7 @@ adjust(o::MixedPrecision{T}; kw...) where T = MixedPrecision(T, adjust(o.rule; k
     Muon(; [eta, mu, nesterov])
 
 The [Muon](https://github.com/KellerJordan/Muon) optimizer, which orthogonalizes
-the momentum matrix before each update, using [`_newton_schulz5`](@ref).
+the momentum matrix before each update, using a Newton-Schulz iteration.
 
 Muon applies only to 2-dimensional parameters, and calling it on any other array
 is an error. Scalar and vector parameters, as well as the input (embedding) and

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -602,6 +602,88 @@ function apply!(o::AdaBelief, state, x::AbstractArray{T}, dx) where T
   return (mt, st, βt .* β), dx′
 end
 
+
+"""
+    Muon(η = 0.02, μ = 0.95, nesterov = true)
+    Muon(; [eta, mu, nesterov])
+
+The [Muon](https://github.com/KellerJordan/Muon) optimizer, which orthogonalizes
+the momentum matrix before each update, using [`_newton_schulz5`](@ref).
+
+Muon applies only to 2-dimensional parameters, and calling it on any other array
+is an error. Scalar and vector parameters, as well as the input (embedding) and
+output (classifier head) layers, should be optimised by another rule such as
+[`AdamW`](@ref) — even though those last two are themselves 2-dimensional, so this
+cannot be detected automatically.
+
+Weight decay is not a field here; compose it instead, as
+`OptimiserChain(WeightDecay(λ), Muon())`.
+
+# Parameters
+- Learning rate (`η == eta`): Amount by which gradients are discounted before updating
+                       the weights.
+- Momentum (`μ == mu`): Controls the acceleration of gradient descent in the
+                  prominent direction, in effect dampening oscillations.
+- Nesterov momentum (`nesterov`): If `true`, orthogonalize a lookahead combination of
+                  the gradient and the momentum, instead of the momentum alone.
+"""
+@def struct Muon <: AbstractRule
+  eta = 0.02
+  mu = 0.95
+  nesterov = true
+end
+
+init(o::Muon, x::AbstractArray{T,2}) where T = zero(x)
+
+function apply!(o::Muon, state, x::AbstractArray{T,2}, dx) where T
+  η, μ = T(o.eta), T(o.mu)
+  Bt = state
+
+  @.. Bt = μ * Bt + (1 - μ) * dx
+  Ut = o.nesterov ? @.((1 - μ) * dx + μ * Bt) : Bt
+  Ot = _newton_schulz5(Ut)
+  γ = real(T)(sqrt(max(1, size(Ot, 1) / size(Ot, 2))))
+  dx′ = @lazy η * γ * Ot
+
+  return Bt, dx′
+end
+
+_muon_needs_matrix(x) = throw(ArgumentError(
+  "Muon can only optimise 2-dimensional parameters, but got one with ndims = $(ndims(x)). " *
+  "Scalar and vector parameters, and the input and output layers, should be optimised " *
+  "by another rule such as AdamW."))
+
+init(o::Muon, x::AbstractArray) = _muon_needs_matrix(x)
+
+apply!(o::Muon, state, x::AbstractArray, dx) = _muon_needs_matrix(x)
+
+"""
+    _newton_schulz5(G::AbstractArray{T,2}, steps::Int=5, eps::Real=1e-7) where T
+
+(Bernstein & Newhouse, 2024; Higham, 2008; Björck and Bowie, 1971; Kovarik, 1970)
+
+Orthogonalizes a matrix `G` using the Newton-Schulz iteration, which is a method for computing the matrix inverse square root.
+This function performs `steps` iterations of the algorithm, starting with an initial guess based on the normalized input matrix.
+The parameter `eps` is used to avoid division by zero in the normalization step.
+"""
+function _newton_schulz5(G::AbstractArray{T,2}, steps::Int=5, eps::Real=1e-7) where T
+  a, b, c = real(T).((3.4445, -4.7750, 2.0315))
+  ϵ = _eps(T, eps)
+  X = G ./ (norm(G) + ϵ)
+  if size(G, 1) > size(G, 2)
+    X = X'
+  end
+  for _ in 1:steps
+    A = X * X'
+    B = b * A + c * A * A
+    X = a * X + B * X
+  end
+  if size(G, 1) > size(G, 2)
+    X = X'
+  end
+  return X
+end
+
 """
     WeightDecay(λ = 5e-4)
     WeightDecay(; [lambda])

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -21,7 +21,7 @@ struct Descent{T} <: AbstractRule
   eta::T
 end
 
-Descent(; eta = 1f-1) = Descent(eta)
+Descent(; eta=1f-1) = Descent(eta)
 
 init(o::Descent, x::AbstractArray) = nothing
 
@@ -121,11 +121,11 @@ struct RMSProp{Teta,Trho,Teps} <: AbstractRule
   centred::Bool
 end
 
-function RMSProp(η, ρ = 0.9, ϵ = 1e-8; centred::Bool = false, centered::Bool = false)
+function RMSProp(η, ρ=0.9, ϵ=1e-8; centred::Bool=false, centered::Bool=false)
   η < 0 && throw(DomainError(η, "the learning rate cannot be negative"))
   return RMSProp(float(η), float(ρ), float(ϵ), centred | centered)
 end
-RMSProp(; eta = 0.001, rho = 0.9, epsilon = 1e-8, kw...) = RMSProp(eta, rho, epsilon; kw...)
+RMSProp(; eta=0.001, rho=0.9, epsilon=1e-8, kw...) = RMSProp(eta, rho, epsilon; kw...)
 
 init(o::RMSProp, x::AbstractArray) = (zero(x), o.centred ? zero(x) : false)
 
@@ -169,26 +169,26 @@ learning algorithm that depends only on the sign of the gradient.
 - Step sizes (`Γ::Tuple == gamma`): Mminimal and maximal allowed step sizes.
 """
 @def struct Rprop <: AbstractRule
-    eta =  1e-3
-    ell = (0.5, 1.2)
-    gamma = (1e-6, 50.0)
+  eta = 1e-3
+  ell = (0.5, 1.2)
+  gamma = (1e-6, 50.0)
 end
 
 init(o::Rprop, x::AbstractArray) = (zero(x), onevalue(o.eta, x))
 
 function apply!(o::Rprop, state, x::AbstractArray{T}, dx) where T
-    ℓ, Γ = T.(o.ell), T.(o.gamma)
-    g, η = state
-  
-    η = broadcast(g, η, dx) do g, η, dx
-        g * dx > 0 ? min(η * ℓ[2], Γ[2]) : g * dx < 0 ? max(η * ℓ[1], Γ[1]) : η
-    end
-    g = broadcast(g, dx) do g, dx
-        g * dx < 0 ? zero(T) : T(dx)
-    end
-    dx′ = @lazy η * sign(g)
+  ℓ, Γ = T.(o.ell), T.(o.gamma)
+  g, η = state
 
-    return (g, η), dx′
+  η = broadcast(g, η, dx) do g, η, dx
+    g * dx > 0 ? min(η * ℓ[2], Γ[2]) : g * dx < 0 ? max(η * ℓ[1], Γ[1]) : η
+  end
+  g = broadcast(g, dx) do g, dx
+    g * dx < 0 ? zero(T) : T(dx)
+  end
+  dx′ = @lazy η * sign(g)
+
+  return (g, η), dx′
 end
 
 """
@@ -284,7 +284,7 @@ function apply!(o::RAdam, state, x::AbstractArray{T}, dx) where T
 
   @.. mt = β[1] * mt + (1 - β[1]) * dx
   @.. vt = β[2] * vt + (1 - β[2]) * abs2(dx)
-  ρ = ρ∞ - 2*t * βt[2] / (1 - βt[2]) |> real
+  ρ = ρ∞ - 2 * t * βt[2] / (1 - βt[2]) |> real
   if ρ > 4
     r = sqrt((ρ - 4) * (ρ - 2) * ρ∞/((ρ∞ - 4) * (ρ∞ - 2) * ρ))
     dx′ = @lazy mt / (1 - βt[1]) / (sqrt(vt / (1 - βt[2])) + ϵ) * η * r
@@ -493,7 +493,7 @@ function apply!(o::NAdam, state, x::AbstractArray{T}, dx) where T
   @.. mt = β[1] * mt + (1 - β[1]) * dx
   @.. vt = β[2] * vt + (1 - β[2]) * abs2(dx)
   dx′ = @lazy (β[1] * mt / (1 - β[1] * βt[1]) + (1 - β[1]) * dx / (1 - βt[1])) /
-          (sqrt(vt * β[2] / (1 - βt[2])) + ϵ) * η
+              (sqrt(vt * β[2] / (1 - βt[2])) + ϵ) * η
 
   return (mt, vt, βt .* β), dx′
 end
@@ -534,12 +534,12 @@ struct AdamW{Teta,Tbeta<:Tuple,Tlambda,Teps} <: AbstractRule
   couple::Bool
 end
 
-function AdamW(η, β = (0.9, 0.999), λ = 0.0, ϵ = 1e-8; couple::Bool = true)
+function AdamW(η, β=(0.9, 0.999), λ=0.0, ϵ=1e-8; couple::Bool=true)
   η < 0 && throw(DomainError(η, "the learning rate cannot be negative"))
   return AdamW(float(η), β, float(λ), float(ϵ), couple)
 end
 
-AdamW(; eta = 0.001, beta = (0.9, 0.999), lambda= 0.0,  epsilon = 1e-8, kw...) =
+AdamW(; eta=0.001, beta=(0.9, 0.999), lambda=0.0, epsilon=1e-8, kw...) =
   AdamW(eta, beta, lambda, epsilon; kw...)
 
 init(o::AdamW, x::AbstractArray{T}) where T = (zero(x), zero(x), T.(o.beta))
@@ -604,87 +604,6 @@ end
 
 
 """
-    Muon(η = 0.02, μ = 0.95, nesterov = true)
-    Muon(; [eta, mu, nesterov])
-
-The [Muon](https://github.com/KellerJordan/Muon) optimizer, which orthogonalizes
-the momentum matrix before each update, using [`_newton_schulz5`](@ref).
-
-Muon applies only to 2-dimensional parameters, and calling it on any other array
-is an error. Scalar and vector parameters, as well as the input (embedding) and
-output (classifier head) layers, should be optimised by another rule such as
-[`AdamW`](@ref) — even though those last two are themselves 2-dimensional, so this
-cannot be detected automatically.
-
-Weight decay is not a field here; compose it instead, as
-`OptimiserChain(WeightDecay(λ), Muon())`.
-
-# Parameters
-- Learning rate (`η == eta`): Amount by which gradients are discounted before updating
-                       the weights.
-- Momentum (`μ == mu`): Controls the acceleration of gradient descent in the
-                  prominent direction, in effect dampening oscillations.
-- Nesterov momentum (`nesterov`): If `true`, orthogonalize a lookahead combination of
-                  the gradient and the momentum, instead of the momentum alone.
-"""
-@def struct Muon <: AbstractRule
-  eta = 0.02
-  mu = 0.95
-  nesterov = true
-end
-
-init(o::Muon, x::AbstractArray{T,2}) where T = zero(x)
-
-function apply!(o::Muon, state, x::AbstractArray{T,2}, dx) where T
-  η, μ = T(o.eta), T(o.mu)
-  Bt = state
-
-  @.. Bt = μ * Bt + (1 - μ) * dx
-  Ut = o.nesterov ? @.((1 - μ) * dx + μ * Bt) : Bt
-  Ot = _newton_schulz5(Ut)
-  γ = real(T)(sqrt(max(1, size(Ot, 1) / size(Ot, 2))))
-  dx′ = @lazy η * γ * Ot
-
-  return Bt, dx′
-end
-
-_muon_needs_matrix(x) = throw(ArgumentError(
-  "Muon can only optimise 2-dimensional parameters, but got one with ndims = $(ndims(x)). " *
-  "Scalar and vector parameters, and the input and output layers, should be optimised " *
-  "by another rule such as AdamW."))
-
-init(o::Muon, x::AbstractArray) = _muon_needs_matrix(x)
-
-apply!(o::Muon, state, x::AbstractArray, dx) = _muon_needs_matrix(x)
-
-"""
-    _newton_schulz5(G::AbstractArray{T,2}, steps::Int=5, eps::Real=1e-7) where T
-
-(Bernstein & Newhouse, 2024; Higham, 2008; Björck and Bowie, 1971; Kovarik, 1970)
-
-Orthogonalizes a matrix `G` using the Newton-Schulz iteration, which is a method for computing the matrix inverse square root.
-This function performs `steps` iterations of the algorithm, starting with an initial guess based on the normalized input matrix.
-The parameter `eps` is used to avoid division by zero in the normalization step.
-"""
-function _newton_schulz5(G::AbstractArray{T,2}, steps::Int=5, eps::Real=1e-7) where T
-  a, b, c = real(T).((3.4445, -4.7750, 2.0315))
-  ϵ = _eps(T, eps)
-  X = G ./ (norm(G) + ϵ)
-  if size(G, 1) > size(G, 2)
-    X = X'
-  end
-  for _ in 1:steps
-    A = X * X'
-    B = b * A + c * A * A
-    X = a * X + B * X
-  end
-  if size(G, 1) > size(G, 2)
-    X = X'
-  end
-  return X
-end
-
-"""
     WeightDecay(λ = 5e-4)
     WeightDecay(; [lambda])
 
@@ -712,15 +631,15 @@ function apply!(o::WeightDecay, state, x::AbstractArray{T}, dx) where T
   return state, dx′
 end
 
-function adjust(r::WeightDecay; gamma = nothing, kw...)
-   if isnothing(gamma)
-     return _adjust(r, NamedTuple(kw))
-   else
-     Base.depwarn("The strength of WeightDecay is now field :lambda, not :gamma", :adjust, force=true)
-     nt = (; lambda = gamma, NamedTuple(kw)...)
-     return _adjust(r, nt)
-   end
- end
+function adjust(r::WeightDecay; gamma=nothing, kw...)
+  if isnothing(gamma)
+    return _adjust(r, NamedTuple(kw))
+  else
+    Base.depwarn("The strength of WeightDecay is now field :lambda, not :gamma", :adjust, force=true)
+    nt = (; lambda=gamma, NamedTuple(kw)...)
+    return _adjust(r, nt)
+  end
+end
 
 """
     SignDecay(λ = 1e-3)
@@ -794,7 +713,7 @@ struct ClipNorm{To,Tp} <: AbstractRule
   p::Tp
   throw::Bool
 end
-ClipNorm(ω = 10, p = 2; throw::Bool = true) = ClipNorm(float(ω), float(p), throw)
+ClipNorm(ω=10, p=2; throw::Bool=true) = ClipNorm(float(ω), float(p), throw)
 
 init(o::ClipNorm, x::AbstractArray) = nothing
 
@@ -869,10 +788,10 @@ end
 init(o::OptimiserChain, x::AbstractArray) = map(opt -> init(opt, x), o.opts)
 
 function apply!(o::OptimiserChain, states, x, dx, dxs...)
-  foldl(tuple.(o.opts, states); init = ((), dx)) do (states′, dx′), (opt, state)
+  foldl(tuple.(o.opts, states); init=((), dx)) do (states′, dx′), (opt, state)
     if dx′ isa Zero
       return (states′..., state), dx′
-    else 
+    else
       state′, dx′ = apply!(opt, state, x, dx′, dxs...)
       return (states′..., state′), dx′
     end
@@ -978,14 +897,14 @@ g = rand(Float16, 2) # A gradient in low precision
 Optimisers.update!(opt_state, x, g)  
 ```
 """
-struct MixedPrecision{T<:Number, O<:AbstractRule} <: AbstractRule
+struct MixedPrecision{T<:Number,O<:AbstractRule} <: AbstractRule
   rule::O
 end
 
 @functor MixedPrecision
 
-MixedPrecision(rule::AbstractRule) = MixedPrecision{Float32, typeof(rule)}(rule)
-MixedPrecision(T::Type, rule::AbstractRule) = MixedPrecision{T, typeof(rule)}(rule)
+MixedPrecision(rule::AbstractRule) = MixedPrecision{Float32,typeof(rule)}(rule)
+MixedPrecision(T::Type, rule::AbstractRule) = MixedPrecision{T,typeof(rule)}(rule)
 
 function init(o::MixedPrecision{T}, x::AbstractArray) where T
   xT = T.(x)
@@ -1007,3 +926,85 @@ end
 
 adjust(o::MixedPrecision{T}, eta::Real) where T = MixedPrecision(T, adjust(o.rule, eta))
 adjust(o::MixedPrecision{T}; kw...) where T = MixedPrecision(T, adjust(o.rule; kw...))
+
+
+"""
+    Muon(η = 0.02, μ = 0.95, nesterov = true)
+    Muon(; [eta, mu, nesterov])
+
+The [Muon](https://github.com/KellerJordan/Muon) optimizer, which orthogonalizes
+the momentum matrix before each update, using [`_newton_schulz5`](@ref).
+
+Muon applies only to 2-dimensional parameters, and calling it on any other array
+is an error. Scalar and vector parameters, as well as the input (embedding) and
+output (classifier head) layers, should be optimised by another rule such as
+[`AdamW`](@ref) — even though those last two are themselves 2-dimensional, so this
+cannot be detected automatically.
+
+Weight decay is not a field here; compose it instead, as
+`OptimiserChain(WeightDecay(λ), Muon())`.
+
+# Parameters
+- Learning rate (`η == eta`): Amount by which gradients are discounted before updating
+                       the weights.
+- Momentum (`μ == mu`): Controls the acceleration of gradient descent in the
+                  prominent direction, in effect dampening oscillations.
+- Nesterov momentum (`nesterov`): If `true`, orthogonalize a lookahead combination of
+                  the gradient and the momentum, instead of the momentum alone.
+"""
+@def struct Muon <: AbstractRule
+  eta = 0.02
+  mu = 0.95
+  nesterov = true
+end
+
+init(o::Muon, x::AbstractArray{T,2}) where T = zero(x)
+
+function apply!(o::Muon, state, x::AbstractArray{T,2}, dx) where T
+  η, μ = T(o.eta), T(o.mu)
+  Bt = state
+
+  @.. Bt = μ * Bt + (1 - μ) * dx
+  Ut = o.nesterov ? @.((1 - μ) * dx + μ * Bt) : Bt
+  Ot = _newton_schulz5(Ut)
+  γ = real(T)(sqrt(max(1, size(Ot, 1) / size(Ot, 2))))
+  dx′ = @lazy η * γ * Ot
+
+  return Bt, dx′
+end
+
+_muon_needs_matrix(x) = throw(ArgumentError(
+  "Muon can only optimise 2-dimensional parameters, but got one with ndims = $(ndims(x)). " *
+  "Scalar and vector parameters, and the input and output layers, should be optimised " *
+  "by another rule such as AdamW."))
+
+init(o::Muon, x::AbstractArray) = _muon_needs_matrix(x)
+
+apply!(o::Muon, state, x::AbstractArray, dx) = _muon_needs_matrix(x)
+
+"""
+    _newton_schulz5(G::AbstractArray{T,2}, steps::Int=5, eps::Real=1e-7) where T
+
+(Bernstein & Newhouse, 2024; Higham, 2008; Björck and Bowie, 1971; Kovarik, 1970)
+
+Orthogonalizes a matrix `G` using the Newton-Schulz iteration, which is a method for computing the matrix inverse square root.
+This function performs `steps` iterations of the algorithm, starting with an initial guess based on the normalized input matrix.
+The parameter `eps` is used to avoid division by zero in the normalization step.
+"""
+function _newton_schulz5(G::AbstractArray{T,2}, steps::Int=5, eps::Real=1e-7) where T
+  a, b, c = real(T).((3.4445, -4.7750, 2.0315))
+  ϵ = _eps(T, eps)
+  X = G ./ (norm(G) + ϵ)
+  if size(G, 1) > size(G, 2)
+    X = X'
+  end
+  for _ in 1:steps
+    A = X * X'
+    B = b * A + c * A * A
+    X = a * X + B * X
+  end
+  if size(G, 1) > size(G, 2)
+    X = X'
+  end
+  return X
+end

--- a/test/rules.jl
+++ b/test/rules.jl
@@ -19,9 +19,19 @@ RULES = [
   RMSProp(centred = true), AdamW(couple=false),
 ]
 
+MATRIX_RULES = [
+  # All the rules at default settings:
+  Muon(),
+  # A few chained combinations:
+  OptimiserChain(WeightDecay(), Muon()),
+  # Not the default:
+  Muon(nesterov=false),
+]
+
 name(o) = typeof(o).name.name  # just for printing testset headings
 name(o::OptimiserChain) = join(name.(o.opts), " → ")
 name(o::RMSProp) = o.centred ? "RMSProp(centred = true)" : :RMSProp
+name(o::Muon) = o.nesterov ? :Muon : "Muon(nesterov = false)"
 
 LOG = Dict()  # for debugging these testsets, this makes it easy to plot each optimiser's loss
 
@@ -33,13 +43,13 @@ end
 
 @testset "independence" begin
   empty!(LOG)
-  @testset "$(name(o))" for o in RULES
+  @testset "$(name(o))" for o in vcat(RULES, MATRIX_RULES)
     w = randn(10, 10)
     w′ = randn(10, 10)
     iloss(x, w, w′) = mean((w*x .- w′*x) .^ 2)
     @test iloss(rand(10, 10), w, w′) > 1
     st = Optimisers.setup(o, w)
-    for t = 1:10^5
+    for t = 1:(10^5)
       x = rand(10, 20)
       gs = loggradient(o)(w -> iloss(x, w, w′), w)
       st, w = Optimisers.update!(st, w, gs...)
@@ -50,10 +60,10 @@ end
 
 @testset "simple sum" begin
   empty!(LOG)
-  @testset "$(name(o))" for o in RULES
+  @testset "$(name(o))" for o in vcat(RULES, MATRIX_RULES)
     m = shuffle!(reshape(1:64, 8, 8) .+ 0.0)
     s = Optimisers.setup(o, m)
-    for _ in 1:10^5
+    for _ in 1:(10^5)
       g = loggradient(o)(x -> sum(abs2, x + x'), m)[1]
       s, m = Optimisers.update!(s, m, g)
     end
@@ -69,13 +79,13 @@ end
 
 @testset "original" begin
   empty!(LOG)
-  @testset "$(name(o))" for o in RULES
+  @testset "$(name(o))" for o in vcat(RULES, MATRIX_RULES)
     w′ = (α = rand(3, 3), β = rand(3, 3))
     w = (α = 5rand(3, 3), β = rand(3, 3))
     st = Optimisers.setup(o, w)
     loss(x, y) = mean((x.α .* x.β .- y.α .* y.β) .^ 2)
     @test loss(w, w′) > 1
-    for i = 1:10^4
+    for i = 1:(10^4)
       gs = loggradient(o)(x -> loss(x, w′), w)
       st, w = Optimisers.update(st, w, gs...)
     end
@@ -97,7 +107,7 @@ end
     y = @SVector randn(10)
     @test s_loss(model, x, y) > 10
     state = Optimisers.setup(o, model)
-    for t = 1:10^3
+    for t = 1:(10^3)
       g = loggradient(o)(m -> s_loss(m, x, y), model)[1]
       state, model = Optimisers.update!(state, model, g)
     end
@@ -111,8 +121,11 @@ end
 end
 
 @testset "element types" begin
-  @testset "$(name(o))" for o in RULES
-    marray = (Float32[1,2], Float64[3,4], Float16[5,6])
+  # Rules which accept any shape are checked on vectors and on matrices, while
+  # those which require a matrix, such as Muon, are checked only on the latter.
+  @testset "$(name(o)), size $sz" for (sz, rules) in ((2,) => RULES, (2, 2) => vcat(RULES, MATRIX_RULES)),
+                                       o in rules
+    marray = map(T -> reshape(T.(1:prod(sz)), sz), (Float32, Float64, Float16))
     types = map(eltype, marray)
 
     # This is a weak test, as it copies & then does `update!`
@@ -120,24 +133,24 @@ end
     @test map(eltype, uparray) == types
 
     # Static version is truly out-of-place:
-    mstatic = (SA{Float32}[1,2], SA{Float64}[3,4]) # , SA{Float16}[5,6])  with Float16, all fail
+    mstatic = map(a -> SArray{Tuple{sz...}}(a), marray[1:2])  # with Float16, all fail
     upstatic = Optimisers.update(Optimisers.setup(o, mstatic), mstatic, mstatic)[2]
     @test map(eltype, upstatic) == types[1:2]
-    @test upstatic[1] isa SVector
+    @test upstatic[1] isa SArray
 
     # With ordinary Array gradient, what happens? Not so important!
     upstatic2 = Optimisers.update(Optimisers.setup(o, mstatic), mstatic, marray[1:2])[2]
     # @test map(eltype, upstatic2) == types[1:2]  # same information
-    if upstatic2[1] isa SVector
-      @test upstatic2[1] isa SVector
+    if upstatic2[1] isa SArray
+      @test upstatic2[1] isa SArray
     else
-      @test_broken upstatic2[1] isa SVector
+      @test_broken upstatic2[1] isa SArray
     end
   end
 end
 
 @testset "gradient types" begin
-  @testset "$(name(o))" for o in RULES
+  @testset "$(name(o))" for o in vcat(RULES, MATRIX_RULES)
     x = (a = ones(2,2), b = transpose(ones(2,2)))
     s = Optimisers.setup(o, x)
 
@@ -285,4 +298,71 @@ end
   @test opt2 isa MixedPrecision{Float64, <:Adam}
 
   @test_throws ArgumentError OptimiserChain(MixedPrecision(Adam()))
+end
+
+@testset "Muon" begin
+  @testset "only matrices" begin
+    # The error must come from setup, not from the first update, so that a model
+    # with unsuitable parameters fails before any training happens.
+    @test_throws ArgumentError Optimisers.setup(Muon(), rand(2, 3, 4))
+    @test_throws ArgumentError Optimisers.setup(Muon(), (α = rand(3, 3), β = rand(3)))
+  end
+
+  @testset "reference algorithm" begin
+    # Momentum is an EMA, and the update is scaled by sqrt(max(1, rows/cols)), which
+    # orthogonalisation alone would not give. Two steps are needed to tell `nesterov`
+    # apart: from B₀ = 0 the lookahead is 1.95 * B₁, a positive multiple which
+    # _newton_schulz5 normalises away, so both settings agree on the first step.
+    η, μ = 0.02, 0.95
+    @testset "nesterov = $nesterov, size ($m, $n)" for nesterov in (true, false),
+                                                       (m, n) in ((6, 4), (4, 6))
+      x = randn(m, n)
+      γ = sqrt(max(1, m / n))
+      st = Optimisers.setup(Muon(η, μ, nesterov), x)
+
+      B = zero(x)
+      for _ in 1:2
+        g = randn(m, n)
+        B = μ * B + (1 - μ) * g
+        U = nesterov ? (1 - μ) * g + μ * B : B
+        expected = x .- η * γ * Optimisers._newton_schulz5(U)
+
+        st, x = Optimisers.update(st, x, g)
+        @test x ≈ expected
+      end
+    end
+  end
+
+  @testset "_newton_schulz5" begin
+    @testset "size ($m, $n)" for (m, n) in ((32, 32), (64, 16), (16, 64))
+      # Give the input a known spectrum: the iteration acts only on the singular
+      # values, so how close it gets depends on the conditioning of the input, not
+      # on the random draw.
+      F = svd(randn(m, n))
+      G = F.U * Diagonal(range(1, 2, length=min(m, n))) * F.Vt
+
+      O = Optimisers._newton_schulz5(G)
+      @test size(O) == (m, n)
+      # The tuned quintic deliberately stops short of exactly orthogonal.
+      @test all(s -> 0.68 < s < 1.14, svdvals(Matrix(O)))
+    end
+
+    # Five fixed steps cannot fully orthogonalise a badly conditioned matrix, but
+    # they still improve it by two orders of magnitude.
+    F = svd(randn(32, 32))
+    G = F.U * Diagonal(range(1, 1e-3, length=32)) * F.Vt
+    @test cond(Matrix(Optimisers._newton_schulz5(G))) < cond(G) / 100
+
+    # Orientation is handled internally, so the iteration commutes with transposing.
+    G = randn(64, 16)
+    @test Optimisers._newton_schulz5(collect(G')) ≈ Optimisers._newton_schulz5(G)'
+
+    # Normalising by the Frobenius norm discards any positive scalar multiple, which
+    # is what makes `nesterov` a no-op on the first step above.
+    @test Optimisers._newton_schulz5(2G) ≈ Optimisers._newton_schulz5(G) rtol=1e-5
+
+    @testset "$T" for T in (Float32, Float64, Float16)
+      @test eltype(Optimisers._newton_schulz5(randn(T, 8, 6))) == T
+    end
+  end
 end


### PR DESCRIPTION
Implements the Muon optimizer as per the [reference implementation](https://github.com/KellerJordan/Muon).

Closes https://github.com/FluxML/Optimisers.jl/issues/230

This implementation follows the reference implementation closely, and allows only for 2D inputs.
Reshaping non 2D inputs could be a possibility but I think it shouldn't be the responsibility of the optimiser.

Regarding testing, a matrix-specific ruleset was created and a test was generalized for matrix input, whereas applicable tests test both the old `RULES` ruleset alongisde the new `MATRIX_RULES` one. Generalization of tests whenever possible is also a possibility.

**References:**
- https://github.com/KellerJordan/Muon
- https://kellerjordan.github.io/posts/muon/

### PR Checklist

- [x] Tests are added
- [x] Documentation, if applicable
